### PR TITLE
docs(readme): add CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 </p>
 
 <p align="center">
+  <img src="https://github.com/marcopag90/telaio/actions/workflows/ci.yml/badge.svg?branch=development" alt="CI">
   <img src="https://img.shields.io/badge/Java-21-orange" alt="Java 21">
   <img src="https://img.shields.io/badge/Powered%20by-Spring%20Boot%204.1.0-6DB33F" alt="Powered by Spring Boot 4.1.0">
   <img src="https://img.shields.io/badge/License-Apache%202.0-blue" alt="License Apache 2.0">


### PR DESCRIPTION
Adds the CI workflow badge to the README header.

Also serves as the end-to-end smoke test of the new CI pipeline and the development ruleset (required `build` check, 0 approvals, up-to-date branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)