### PR TITLE
fix(core): enforce defaultFilter on delete + filtering docs

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
 github: marcopag90
-custom: [ "https://www.paypal.me/MarcoPag90" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '25'
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload test reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '25'
@@ -30,7 +30,7 @@ jobs:
         run: mvn -B clean install -DskipTests
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: telaio-${{ github.ref_name }}
           path: |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://github.com/marcopag90/telaio/actions/workflows/ci.yml/badge.svg?branch=development" alt="CI">
   <img src="https://img.shields.io/badge/Java-21-orange" alt="Java 21">
   <img src="https://img.shields.io/badge/Powered%20by-Spring%20Boot%204.1.0-6DB33F" alt="Powered by Spring Boot 4.1.0">
-  <img src="https://img.shields.io/badge/License-Apache%202.0-blue" alt="License Apache 2.0">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue" alt="License Apache 2.0"></a>
   <img src="https://img.shields.io/badge/status-pre--release%20(0.0.1--SNAPSHOT)-lightgrey" alt="Status pre-release (0.0.1-SNAPSHOT)">
 </p>
 
@@ -55,6 +55,10 @@ service, a repository. Telaio collapses that into one abstraction:
   (`JsonViewDalRbacAdapter`).
 - **Operation-level authorization.** A `DalAuthAdapter` decides, per principal and per operation,
   whether create/read/update/delete is allowed — independent of RBAC's field filtering.
+- **Implicit baseline filtering.** Override `defaultFilter()` and a filter is silently AND-combined
+  with every client query — per-principal if you like — and enforced on reads, updates, and deletes
+  alike: hidden rows behave like missing ones. See
+  [Filtering built in](#filtering-built-in--powered-by-turkraft-spring-filter).
 - **Exposure control without extra code.** `@DalService(internal = true)` keeps a DAL fully
   functional in-process while hiding it from REST and OpenAPI entirely; `@DalService(operations =
   {...})` exposes only a CRUD subset (e.g. read-only) and answers everything else with `404`/`405`.
@@ -102,6 +106,40 @@ audience:
 
 Both strategies are covered in depth in the [security guide](docs/security-guide.md); filter-side
 renaming is in the [REST API reference](docs/rest-api.md).
+
+## Filtering built-in — powered by Turkraft Spring Filter
+
+Every list endpoint accepts a `q` parameter in
+[**Turkraft Spring Filter**](https://github.com/turkraft/springfilter) syntax — a compact,
+SQL-like expression language the client composes freely:
+
+```bash
+curl "http://localhost:8080/dal/v1/products?q=category:'electronics'%20and%20price>500"
+curl "http://localhost:8080/dal/v1/products?q=category:'electronics'&sort=price,desc&page=0&size=5"
+```
+
+The same language also works **server-side**: override `defaultFilter()` in a DAL and you get an
+implicit **baseline filter**, AND-combined with whatever the client sends and enforced on **every
+operation** — list reads, by-id reads, updates, and deletes. The client cannot bypass it: an entity
+hidden by the filter behaves exactly like one that does not exist. And since it is evaluated per
+request, it can depend on the authenticated principal. (It is a *visibility* filter over existing
+rows — it does not constrain the payload of creates; pair it with field-level RBAC to control what
+can be written.) From the showcase's `ArticleDalService` (abridged):
+
+```java
+@Override
+protected @Nullable FilterNode defaultFilter() {
+    if (isPowerUser()) {        // role check via DalSecurityContextHelper — full code in the showcase
+        return null;            // DEVELOPER/ADMIN see everything: drafts, archived, published
+    }
+    return filterBuilder.field(propertyName(Article::getStatus))   // type-safe property reference
+        .equal(filterBuilder.input(ArticleStatus.PUBLISHED))
+        .get();                 // everyone else is silently scoped to PUBLISHED articles
+}
+```
+
+The full query grammar is in the [REST API reference](docs/rest-api.md#filtering-query-language);
+the `defaultFilter()` hook is covered in the [core module docs](docs/modules/core.md).
 
 ## Quick start
 
@@ -410,8 +448,8 @@ For commercial support, contact: [marcopag90@gmail.com](mailto:marcopag90@gmail.
 
 ## Support the Project
 
-If Telaio saves you time or is used in your company, consider sponsoring its development:
-[**PayPal**](https://www.paypal.me/MarcoPag90).
+If Telaio saves you time or is used in your company, consider sponsoring its development through
+[**GitHub Sponsors**](https://github.com/sponsors/marcopag90).
 Sponsorship helps fund maintenance, documentation, examples, bug fixing, and new features.
 
 ## License

--- a/docs/modules/core.md
+++ b/docs/modules/core.md
@@ -135,7 +135,9 @@ Available hooks:
 - `finalizeAfterCreate/Update/Read/ReadOne` — Side-effects after the operation
 - `finalizeBeforeDelete/AfterDelete` — Hooks around deletion (receive the entity id)
 - `defaultSort()` — Default sort order when none is requested
-- `defaultFilter()` — Implicit filter AND-combined with the request's `q` parameter
+- `defaultFilter()` — Implicit filter AND-combined with the request's `q` parameter and enforced on
+  every operation addressing existing rows (list and by-id reads, updates, deletes — a hidden entity
+  behaves like a missing one; create payloads are not scoped by it)
 
 ### 5. Validate Input Automatically
 

--- a/docs/modules/jpa.md
+++ b/docs/modules/jpa.md
@@ -144,7 +144,7 @@ Available hooks (from `AbstractDal`):
 - `finalizeAfterCreate/Update/Read/ReadOne(E)` — Side-effects after the operation
 - `finalizeBeforeDelete/AfterDelete(I)` — Hooks around deletion (receive the entity id)
 - `defaultSort()` → `Sort` — Default sort order
-- `defaultFilter()` → `FilterNode?` — Implicit baseline filter
+- `defaultFilter()` → `FilterNode?` — Implicit baseline filter (enforced on reads, updates and deletes)
 
 ### 5. Use Filtering
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -225,6 +225,8 @@ No response body is returned on successful deletion.
 - **204 No Content** — Entity deleted successfully.
 - **403 Forbidden** — Principal not authorized to delete.
 - **404 Not Found** — DAL service not found, the URI exposes no operation at all, or the entity doesn't exist.
+  An entity hidden by the DAL's `defaultFilter()` counts as non-existent: it cannot be deleted, exactly as it
+  cannot be read or updated.
 - **405 Method Not Allowed** — DELETE is not exposed but the URI still exposes another method (`Allow` header lists
   them).
 

--- a/telaio-core/src/main/java/io/paganbit/telaio/core/AbstractDal.java
+++ b/telaio-core/src/main/java/io/paganbit/telaio/core/AbstractDal.java
@@ -271,6 +271,12 @@ public abstract class AbstractDal<E, I>
      * The default implementation returns {@code null}, meaning no additional filtering is applied.
      * </p>
      *
+     * <p>The default filter constrains <strong>every operation</strong>: list reads (AND-combined
+     * with the caller's own filter, see {@link #combineWithDefaultFilter(FilterNode)}), by-id
+     * reads (via {@link #executeReadOne(Object)}), and therefore also {@link #update(Object, Map)}
+     * and {@link #delete(Object)}, which load the entity through the filtered by-id lookup — a
+     * hidden entity behaves exactly like a missing one.</p>
+     *
      * @return a {@link FilterNode} representing the filter condition,
      * or {@code null} if no default filter applies.
      */
@@ -373,6 +379,7 @@ public abstract class AbstractDal<E, I>
 
     @Override
     public void delete(I id) {
+        executeReadOne(id).orElseThrow(() -> new DalEntityNotFoundException(this.getEntityClass(), id));
         final var transaction = finalizeTransaction(transactionManager, transactionPolicy.forDelete());
         transaction.executeWithoutResult(ex -> {
             finalizeBeforeDelete(id);
@@ -488,10 +495,19 @@ public abstract class AbstractDal<E, I>
 
     /**
      * Reads an entity by its ID.
-     * Executed within the transactional context.
+     * Executed within the transactional context when invoked via {@link #readOne(Object)};
+     * {@link #update(Object, Map)} and {@link #delete(Object)} also invoke it directly,
+     * outside a transaction, as their visibility pre-check.
+     *
+     * <p><strong>Contract:</strong> implementations MUST honor {@link #defaultFilter()} — the
+     * by-id lookup has to be combined with the default filter so that a hidden entity resolves
+     * to an empty {@link Optional}. Both {@link #update(Object, Map)} and {@link #delete(Object)}
+     * rely on this method as the single enforcement point of the default filter for by-id
+     * operations.</p>
      *
      * @param id the ID of the entity to read
-     * @return the entity with the given ID
+     * @return the entity with the given ID, or empty if it does not exist or is hidden by the
+     * default filter
      */
     protected abstract Optional<E> executeReadOne(I id);
 

--- a/telaio-core/src/main/java/io/paganbit/telaio/core/Dal.java
+++ b/telaio-core/src/main/java/io/paganbit/telaio/core/Dal.java
@@ -64,6 +64,10 @@ public interface Dal<E, I> extends DalMetadata<E, I> {
     /**
      * Deletes an entity identified by {@code id}.
      *
+     * <p>An entity that does not exist — or that is hidden by the DAL's default filter — cannot
+     * be deleted: the operation fails with
+     * {@link io.paganbit.telaio.core.exception.DalEntityNotFoundException}.</p>
+     *
      * @param id the entity identifier
      */
     @DalOperation(DalOperationType.DELETE)

--- a/telaio-core/src/test/java/io/paganbit/telaio/core/AbstractDalTest.java
+++ b/telaio-core/src/test/java/io/paganbit/telaio/core/AbstractDalTest.java
@@ -397,12 +397,28 @@ class AbstractDalTest {
             );
             when(mockTransactionPolicy.forDelete()).thenReturn(new DefaultTransactionDefinition());
 
+            spiedService.simulateEmptyResult = false;
             spiedService.delete(id);
+            spiedService.simulateEmptyResult = true;
 
             verify(spiedTransactionTemplate, times(1)).execute(any());
+            verify(spiedService, times(1)).executeReadOne(id);
             verify(spiedService, times(1)).finalizeBeforeDelete(id);
             verify(spiedService, times(1)).executeDelete(id);
             verify(spiedService, times(1)).finalizeAfterDelete(any());
+        }
+
+        @Test
+        void testDelete_shouldThrowNotFoundWhenEntityIsMissingOrHidden() {
+            // executeReadOne is the single defaultFilter enforcement point for by-id operations:
+            // an entity hidden by the filter resolves to empty, exactly like a missing one
+            // (simulateEmptyResult is true by default).
+            assertThrows(DalEntityNotFoundException.class, () -> spiedService.delete(1L));
+
+            verify(spiedService, never()).finalizeBeforeDelete(any());
+            verify(spiedService, never()).executeDelete(any());
+            verify(spiedService, never()).finalizeAfterDelete(any());
+            verify(mockTransactionPolicy, never()).forDelete();
         }
     }
 

--- a/telaio-jpa/src/test/java/io/paganbit/telaio/jpa/JpaDalTest.java
+++ b/telaio-jpa/src/test/java/io/paganbit/telaio/jpa/JpaDalTest.java
@@ -6,6 +6,7 @@ import com.turkraft.springfilter.converter.FilterSpecificationConverter;
 import com.turkraft.springfilter.converter.FilterStringConverter;
 import com.turkraft.springfilter.parser.node.FilterNode;
 import io.paganbit.telaio.core.beans.DalPropertyMerger;
+import io.paganbit.telaio.core.exception.DalEntityNotFoundException;
 import io.paganbit.telaio.core.transaction.DalTransactionPolicy;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.metamodel.EntityType;
@@ -23,15 +24,16 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
 import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -320,6 +322,69 @@ class JpaDalTest {
 
         assertThat(result).isNotNull().isNotSameAs(input);
         verify(specificationConverter).convert(defaultFilter);
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Delete honors the default filter (by-id operations go through the filtered lookup)
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns a fully initialized DAL whose {@code defaultFilter()} converts to the given
+     * specification, so the filtered by-id lookup is exercised end-to-end at the mock level.
+     */
+    private DefaultFilteredJpaDal filteredDal(FilterNode defaultFilter) {
+        DefaultFilteredJpaDal dal = new DefaultFilteredJpaDal(repository, entityManager, defaultFilter);
+        wireAbstractDalCollaborators(dal);
+        dal.setSpecificationConverter(specificationConverter);
+        dal.afterPropertiesSet();
+        return dal;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void delete_entityHiddenByDefaultFilter_throwsNotFoundAndNeverDeletes() {
+        FilterNode defaultFilter = mock(FilterNode.class);
+        DefaultFilteredJpaDal dal = filteredDal(defaultFilter);
+        FilterSpecification<TestEntity> defaultSpec = mock(FilterSpecification.class);
+        doReturn(defaultSpec).when(specificationConverter).convert(defaultFilter);
+        // The filtered by-id lookup does not see the row: hidden behaves exactly like missing.
+        when(repository.findOne(any(Specification.class))).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(DalEntityNotFoundException.class)
+            .isThrownBy(() -> dal.delete(42L));
+
+        verify(repository, never()).deleteById(any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void update_entityHiddenByDefaultFilter_throwsNotFoundAndNeverSaves() {
+        FilterNode defaultFilter = mock(FilterNode.class);
+        DefaultFilteredJpaDal dal = filteredDal(defaultFilter);
+        FilterSpecification<TestEntity> defaultSpec = mock(FilterSpecification.class);
+        doReturn(defaultSpec).when(specificationConverter).convert(defaultFilter);
+        when(repository.findOne(any(Specification.class))).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(DalEntityNotFoundException.class)
+            .isThrownBy(() -> dal.update(42L, Map.of()));
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void delete_visibleEntity_deletesById() {
+        FilterNode defaultFilter = mock(FilterNode.class);
+        DefaultFilteredJpaDal dal = filteredDal(defaultFilter);
+        FilterSpecification<TestEntity> defaultSpec = mock(FilterSpecification.class);
+        doReturn(defaultSpec).when(specificationConverter).convert(defaultFilter);
+        when(repository.findOne(any(Specification.class))).thenReturn(Optional.of(new TestEntity()));
+        when(transactionPolicy.forDelete()).thenReturn(new DefaultTransactionDefinition());
+
+        dal.delete(42L);
+
+        verify(repository).findOne(any(Specification.class));
+        verify(repository).deleteById(42L);
     }
 
     // -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What

- **fix(core)**: `delete()` now goes through the filter-honoring `executeReadOne(id)` before deleting — an entity hidden by `defaultFilter()` (or missing) raises `DalEntityNotFoundException` → 404, mirroring `update()`. Closes the last defaultFilter bypass (read/readOne/update were already covered).
- **docs(readme)**: new *Filtering built-in — powered by Turkraft Spring Filter* section (client `q` syntax + server-side `defaultFilter()`), Why-Telaio bullet, GitHub Sponsors link, clickable license badge, module docs aligned.
- **ci**: actions bumped to Node 24 majors (checkout v7, setup-java v5, upload-artifact v7) — removes the deprecation warning.
- **chore(funding)**: PayPal removed, GitHub Sponsors only.

## Behavior change

DELETE of a non-existent id: silent 204 → **404**, aligning with the documented REST contract. Changelog entry due at next release.

## Verification

Full `mvn clean verify` green twice (49 showcase ITs included); new unit tests in core (hidden delete → 404, no side effects) and jpa (hidden delete/update blocked, visible delete works). Reviewed by a 4-perspective panel (architecture, code+security, module boundaries, docs) — no blocking findings, all should-fixes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)