### PR TITLE
test: docs-only CI skip validation (do not merge)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -325,3 +325,5 @@ Ensure your repository extends `JpaDalRepository<E, I>` with the correct generic
 - **GitHub**: [github.com/marcopag90/telaio](https://github.com/marcopag90/telaio)
 - **Source**: Clone and explore `telaio-showcase` for complete examples
 - **Tests**: Browse `telaio-web/src/test/…` for request/response examples
+
+<!-- CI docs-only skip validation: temporary PR, close without merging -->


### PR DESCRIPTION
Throwaway PR validating that a docs-only diff skips the build job while keeping the required check satisfied. Will be closed without merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)