### PR TITLE
feat(web): map malformed filter syntax to 400 Bad Request

### DIFF
--- a/telaio-openapi/src/main/java/com/paganbit/telaio/openapi/generator/DalPathsGenerator.java
+++ b/telaio-openapi/src/main/java/com/paganbit/telaio/openapi/generator/DalPathsGenerator.java
@@ -48,6 +48,7 @@ public class DalPathsGenerator {
     private static final String CONCURRENT_MODIFICATION_MESSAGE =
         "Concurrent modification of a versioned entity — re-read and retry";
     private static final String DAL_SERVICE_OR_ENTITY_NOT_FOUND_MESSAGE = "DAL service or entity not found";
+    private static final String MALFORMED_READ_REQUEST_MESSAGE = "Malformed filter or pagination parameters";
     private static final String UNEXPECTED_ERROR_MESSAGE = "Unexpected error";
 
     public DalPathsGenerator(
@@ -139,6 +140,7 @@ public class DalPathsGenerator {
         pageableParameters().forEach(operation::addParametersItem);
         return operation.responses(new ApiResponses()
             .addApiResponse("200", jsonResponse("Page of entities", pageSchema(entityRef)))
+            .addApiResponse("400", problemResponse(MALFORMED_READ_REQUEST_MESSAGE, problemDetailRef))
             .addApiResponse("403", problemResponse(ACCESS_DENIED_MESSAGE, problemDetailRef))
             .addApiResponse("404", problemResponse("DAL service not found", problemDetailRef))
             .addApiResponse("500", problemResponse(UNEXPECTED_ERROR_MESSAGE, problemDetailRef)));

--- a/telaio-openapi/src/test/java/com/paganbit/telaio/openapi/generator/DalPathsGeneratorTest.java
+++ b/telaio-openapi/src/test/java/com/paganbit/telaio/openapi/generator/DalPathsGeneratorTest.java
@@ -72,7 +72,8 @@ class DalPathsGeneratorTest {
 
         Operation read = collection.getGet();
         assertThat(read.getParameters()).extracting(Parameter::getName).contains("q", "page", "size", "sort");
-        assertThat(read.getResponses()).containsKeys("200", "403", "404", "500");
+        assertThat(read.getResponses()).containsKeys("200", "400", "403", "404", "500");
+        assertErrorBody(read, "400");
         assertErrorBody(read, "403");
         assertErrorBody(read, "404");
         assertErrorBody(read, "500");

--- a/telaio-showcase/src/test/java/com/paganbit/telaio/showcase/it/DalApiErrorsIT.java
+++ b/telaio-showcase/src/test/java/com/paganbit/telaio/showcase/it/DalApiErrorsIT.java
@@ -24,13 +24,13 @@ class DalApiErrorsIT extends AbstractShowcaseIT {
     }
 
     @Test
-    void malformedFilterIsRejectedNotSilentlyIgnored() {
+    void malformedFilterIsRejectedWithBadRequest() {
         // Passed raw (TestRestTemplate encodes once); unbalanced parens are a Turkraft syntax error.
         ResponseEntity<String> response = list(USER, "products", "q=(((");
 
-        assertThat(response.getStatusCode().is2xxSuccessful())
+        assertThat(response.getStatusCode())
             .as("a malformed filter must never be treated as 'no filter' and return rows")
-            .isFalse();
-        assertThat(response.getStatusCode().isError()).isTrue();
+            .isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(tree(response).path("detail").asString()).isEqualTo("Malformed filter expression");
     }
 }

--- a/telaio-web/src/main/java/com/paganbit/telaio/web/DalRestApiV1.java
+++ b/telaio-web/src/main/java/com/paganbit/telaio/web/DalRestApiV1.java
@@ -67,6 +67,10 @@ public interface DalRestApiV1 {
     @Operation(summary = "Read a page of objects from the specified DAL")
     @ApiResponse(responseCode = "200", description = "Page of entities")
     @ApiResponse(
+        responseCode = "400",
+        description = "Malformed filter or pagination parameters",
+        content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
         responseCode = "403",
         description = "Access denied",
         content = @Content(schema = @Schema(implementation = ProblemDetail.class)))

--- a/telaio-web/src/main/java/com/paganbit/telaio/web/exception/TelaioWebExceptionHandler.java
+++ b/telaio-web/src/main/java/com/paganbit/telaio/web/exception/TelaioWebExceptionHandler.java
@@ -5,6 +5,7 @@ import com.paganbit.telaio.core.exception.DalEntityValidationException;
 import com.paganbit.telaio.core.exception.DalNotFoundException;
 import com.paganbit.telaio.core.exception.DalRegistryException;
 import com.paganbit.telaio.web.validation.ValidationError;
+import com.turkraft.springfilter.parser.InvalidSyntaxException;
 import io.swagger.v3.oas.annotations.Hidden;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +44,19 @@ public class TelaioWebExceptionHandler {
         ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "Validation failed");
         problem.setProperty("errors", toValidationErrors(ex.getErrors()));
         return problem;
+    }
+
+    /**
+     * Maps a malformed {@code q} filter expression to {@code 400 Bad Request}. Raised by the filter
+     * parser before the operation reaches the {@code Dal}, so a syntactically invalid filter is rejected
+     * rather than silently ignored (which would otherwise leak every row). The body carries a stable,
+     * generic detail; the parser's own message (which echoes fragments of the client's input) stays in
+     * the on-demand debug log only.
+     */
+    @ExceptionHandler(InvalidSyntaxException.class)
+    ProblemDetail handleInvalidFilterSyntax(InvalidSyntaxException ex) {
+        log.debug("Malformed filter expression rejected: {}", ex.getMessage());
+        return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "Malformed filter expression");
     }
 
     /**

--- a/telaio-web/src/test/java/com/paganbit/telaio/web/DalRestApiV1ControllerTest.java
+++ b/telaio-web/src/test/java/com/paganbit/telaio/web/DalRestApiV1ControllerTest.java
@@ -1,12 +1,13 @@
 package com.paganbit.telaio.web;
 
-import com.turkraft.springfilter.converter.FilterStringConverter;
 import com.paganbit.telaio.core.adapter.DalOperationAdapter;
 import com.paganbit.telaio.core.exception.DalNotFoundException;
 import com.paganbit.telaio.core.registry.DalManager;
 import com.paganbit.telaio.web.adapter.WebDalOperationAdapter;
 import com.paganbit.telaio.web.exception.TelaioWebExceptionHandler;
 import com.paganbit.telaio.web.registry.WebDalOperationAdapterRegistry;
+import com.turkraft.springfilter.converter.FilterStringConverter;
+import com.turkraft.springfilter.parser.InvalidSyntaxException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -117,6 +118,20 @@ class DalRestApiV1ControllerTest {
     void deleteCompany_shouldReturnNoContent() throws Exception {
         mockMvc.perform(delete("/dal/v1/company/1"))
             .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void readCompanies_malformedFilter_shouldReturnBadRequest() throws Exception {
+        doThrow(new InvalidSyntaxException("mismatched input '(' expecting {...}"))
+            .when(filterStringConverter).convert("(((");
+
+        mockMvc.perform(get("/dal/v1/company")
+                .param("q", "(((")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.detail").value("Malformed filter expression"));
     }
 
     @Test


### PR DESCRIPTION
## Why

A malformed `q` filter expression (e.g. `q=(((`) currently surfaces as an unhandled Turkraft `InvalidSyntaxException` → **500** with Spring Boot's default error body. `docs/rest-api.md` has always documented this case as a **400** ("Malformed filter expression"), so the implementation lagged behind the documented contract. Reclassifying it as a client fault also fixes error-rate hygiene (a bad filter is not a server fault) and removes an ERROR-level stack trace per malformed request (a log-flooding vector).

## What

- **telaio-web** — `TelaioWebExceptionHandler`: new `@ExceptionHandler(InvalidSyntaxException.class)` → RFC 9457 `ProblemDetail` **400** with the stable detail `"Malformed filter expression"`. The parser's own message (which echoes fragments of client input) goes to `log.debug` only, per the project logging policy (4xx at DEBUG, no internals in bodies).
- **telaio-web** — `DalRestApiV1.read`: documented `@ApiResponse` **400** "Malformed filter or pagination parameters" (single generic 400, consistent with the wording already used in `docs/rest-api.md`).
- **telaio-openapi** — `DalPathsGenerator.readOperation`: the generated per-DAL OpenAPI now documents the same 400 with `application/problem+json` body.

The exception is thrown in the controller **before** the operation reaches the `Dal`, so audit/metrics semantics are intentionally untouched (same as unknown-DAL 404s and binding failures).

## Verification

- Full reactor `mvn clean verify` green (all modules, Testcontainers matrix, showcase ITs).
- New unit test `DalRestApiV1ControllerTest.readCompanies_malformedFilter_shouldReturnBadRequest` (400 + `application/problem+json` + detail).
- `DalPathsGeneratorTest` asserts the 400 response with problem body on the read operation.
- Showcase E2E `DalApiErrorsIT` **strengthened** from "any error" to exactly `400` + detail `"Malformed filter expression"` — the contract is now pinned end-to-end over real HTTP against PostgreSQL.
- Review panel (java-architect, diff-level, security-auditor, module-boundary, documentation-engineer): no blocking findings; `docs/rest-api.md` already matches, no doc change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)