### PR TITLE
build: add JaCoCo coverage reporting to the Maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>
         <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
+        <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
         <!-- testcontainers -->
         <testcontainers.image.postgresql>postgres:17</testcontainers.image.postgresql>
         <testcontainers.image.mysql>mysql:8.4</testcontainers.image.mysql>
@@ -173,6 +174,26 @@
                         <id>attach-sources</id>
                         <goals>
                             <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/telaio-showcase/pom.xml
+++ b/telaio-showcase/pom.xml
@@ -21,6 +21,7 @@
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <gpg.skip>true</gpg.skip>
         <skipPublishing>true</skipPublishing>
+        <jacoco.skip>true</jacoco.skip>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- Configure `jacoco-maven-plugin` **0.8.15** in the root pom (version-managed via the `jacoco-maven-plugin.version` property).
- `prepare-agent` instruments Surefire runs; the `report` goal is bound to the **`test` phase**, so both `mvn test` and the CI `mvn clean verify` produce per-module reports under `target/site/jacoco` (HTML/XML/CSV) with no workflow changes.
- `telaio-showcase` opts out via `<jacoco.skip>true</jacoco.skip>` (demo app, never published). `telaio-bom` is parentless, so it stays out by construction.

## Verification
Full-reactor `mvn clean test` passes and generates reports for all 10 library modules (line coverage 81–99%); no report for showcase/bom as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)