### PR TITLE
ci: track dev container feature updates with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,3 +43,24 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # Dev container Features only: the feature references in devcontainer.json and
+  # the matching devcontainer-lock.json entries. Dependabot does NOT bump the base
+  # image — moving off :jdk25-v1 stays a deliberate manual decision.
+  - package-ecosystem: "devcontainers"
+    directory: "/" # Features are found in any valid dev container location below it
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Rome"
+    target-branch: "development"
+    commit-message:
+      prefix: "chore"
+      include: "scope" # -> "chore(deps): bump ..."
+    groups:
+      devcontainers-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ on:
       - 'LICENSE'
       - '.gitignore'
       - '.github/FUNDING.yml'
+      - '.github/dependabot.yml'
       - '.github/workflows/publish.yml'
       - '.github/workflows/coverage.yml'
       - '.claude/**'
@@ -73,7 +74,7 @@ jobs:
             exit 0
           fi
           # KEEP IN SYNC with the push paths-ignore list at the top of this file.
-          IGNORE_REGEX='^(docs/.*|\.claude/.*|\.devcontainer/.*|LICENSE|\.gitignore|\.github/FUNDING\.yml|\.github/workflows/publish\.yml|\.github/workflows/coverage\.yml|.*\.md)$'
+          IGNORE_REGEX='^(docs/.*|\.claude/.*|\.devcontainer/.*|LICENSE|\.gitignore|\.github/FUNDING\.yml|\.github/dependabot\.yml|\.github/workflows/publish\.yml|\.github/workflows/coverage\.yml|.*\.md)$'
           # Three-dot diff (merge-base..head): the same semantics GitHub itself
           # applies to pull_request path filters. Fail open on any git error.
           if ! files=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}"); then


### PR DESCRIPTION
Two related changes to the CI/Dependabot configuration.

## 1. `devcontainers` ecosystem in `.github/dependabot.yml`

Matches the shape of the two existing entries (weekly Monday 07:00 Europe/Rome, `target-branch: development`, minor/patch grouped).

`.devcontainer/devcontainer.json` references `ghcr.io/devcontainers/features/docker-in-docker:2` — a floating major — and `devcontainer-lock.json` pins it to 2.17.0 plus digest. Without an updater the lockfile silently freezes there: pinning without a bump path is just staleness.

The ecosystem updates **the feature references and the lockfile entries only**. It does not bump the base image, so moving off `:jdk25-v1` stays a deliberate manual decision — which is the point of pinning it.

`prefix: chore` keeps the generated commits conventional (`chore(deps): bump ...`), consistent with the `chore(devcontainer)` used for the dev container itself; `build` and `ci` are already taken by the Maven and Actions entries.

## 2. `.github/dependabot.yml` excluded from the docs-only build gate

Same category as `FUNDING.yml`, `publish.yml` and `coverage.yml`, which are already excluded — the Dependabot configuration cannot affect the Maven build. Added to both of the two spots that must stay in sync.

This PR still runs `build`, because it touches `ci.yml` itself, which is deliberately *not* in the ignore list.

## Note on taking effect

Dependabot reads `dependabot.yml` from the **default branch** only, so this needs cherry-picking to `main` after the merge — otherwise the entry stays invisible until the next release merges `development` into `main`. The file already documents that constraint at the top. Manifests are still scanned on `target-branch` (`development`), so `.devcontainer/**` would not need to be on `main` for it to work — though it now is.

## Verified

- `dependabot.yml` parses as YAML and resolves to three update entries (`maven`, `github-actions`, `devcontainers`).
- The two halves of the ignore list agree: 10 entries in `paths-ignore`, 10 alternatives in `IGNORE_REGEX`. Regex checked against representative paths — `dependabot.yml`, `FUNDING.yml`, `.devcontainer/**`, `docs/**`, `*.md`, `.claude/**`, `LICENSE` are ignored; `ci.yml`, `pom.xml`, `telaio-core/src/**`, `.gitattributes` still build.