### PR TITLE
docs(devcontainer): correct three claims about the JetBrains client

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -19,10 +19,11 @@ The image is `linux/amd64` only.
 `devcontainer.json` is an open specification and `customizations` is namespaced per tool, so the same file serves every
 client:
 
-- **IntelliJ IDEA** — open `devcontainer.json` in the editor, then use the *Create Dev Container* gutter icon →
-  **Create Dev Container and Mount Sources…** (the *Clone Sources* variant clones from a remote instead, losing
-  uncommitted work). Progress shows in the *Services* tool window; then *Connect*. The first connection downloads the
-  backend IDE into the `telaio-jetbrains` volume, so only the first one is slow.
+- **IntelliJ IDEA** — open `devcontainer.json` in the editor, then use the *Create Dev Container* gutter icon → **Create
+  Dev Container and Mount Sources…** (the *Clone Sources* variant clones from a remote instead, losing uncommitted
+  work). Progress shows in the *Services* tool window; then *Connect* — the first connection downloads the backend IDE,
+  so it is the slow one. The backend then runs as a JVM inside the container; the client is a frame of your local IDE,
+  not a separate application, so closing the local IDE ends the session while the container keeps running.
 - **VS Code** — the *Dev Containers* extension → *Reopen in Container*.
 - **CLI** — no IDE needed:
 
@@ -53,12 +54,12 @@ host socket, a container published on the host's `localhost:5432` would not be r
 
 ## Volumes
 
-| Volume             | Mount                | Why                                                                                                                                                                  |
-|--------------------|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `telaio-dind`      | `/var/lib/docker`    | The inner daemon's image store. The Testcontainers vendor matrix pulls ~6 GB (Oracle XE and SQL Server dominate); without this they are re-pulled on every recreate. |
-| `telaio-m2`        | `~/.m2`              | Maven repository.                                                                                                                                                    |
-| `telaio-jetbrains` | `~/.cache/JetBrains` | The JetBrains backend IDE is ~1.5 GB.                                                                                                                                |
-| `telaio-gh`        | `~/.config/gh`       | Keeps the `gh` login across recreates.                                                                                                                               |
+| Volume             | Mount                | Why                                                                                                                                                                                                |
+|--------------------|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `telaio-dind`      | `/var/lib/docker`    | The inner daemon's image store. The Testcontainers vendor matrix pulls ~6 GB (Oracle XE and SQL Server dominate); without this they are re-pulled on every recreate.                               |
+| `telaio-m2`        | `~/.m2`              | Maven repository.                                                                                                                                                                                  |
+| `telaio-jetbrains` | `~/.cache/JetBrains` | Caches and indexes of the JetBrains backend. Not the backend itself — that is deployed under `/tmp`, outside our control. What this saves is re-indexing a 14-module reactor after every recreate. |
+| `telaio-gh`        | `~/.config/gh`       | Keeps the `gh` login across recreates.                                                                                                                                                             |
 
 Deleting a volume is safe — it only costs a re-download. `post-create.sh` hands the fresh (root-owned)
 volumes to the container user on first create.
@@ -72,14 +73,21 @@ volumes to the container user on first create.
   `post-create.sh` registers the workspace as a git `safe.directory` as a backstop.
 - **Signed releases are not supported in here.** No GPG key is mounted; signing happens in CI (`publish.yml`,
   `-Dgpg.signer=bc`). Use the container for building and testing.
-- **`portsAttributes` is honoured unevenly.** JetBrains IDEs read only `label` and ignore the rest, so
-  `onAutoForward` applies to VS Code and the `devcontainer` CLI alone. Nothing breaks either way.
+- **`portsAttributes` is honored unevenly.** The JetBrains documentation states that only `label` is supported. In
+  practice IDEA does keep the rest in its container model, but treat `onAutoForward` as reliable on VS Code and the
+  `devcontainer` CLI only. Nothing breaks either way.
 - **One container at a time.** Each client creates its own container, and they all mount `telaio-dind`
   at `/var/lib/docker` — two inner daemons over one storage directory contend for the same locks. Remove the previous
-  container before opening the project with a different client:
+  container before opening the project with a different client. The label to filter on depends on who created it:
 
   ```bash
+  # devcontainer CLI and VS Code — lowercased drive letter, backslashes
   docker rm -f $(docker ps -aq --filter 'label=devcontainer.local_folder=d:\path\to\telaio')
+
+  # IntelliJ IDEA — original case, forward slashes
+  docker rm -f $(docker ps -aq --filter 'label=com.intellij.devcontainer.sources.path=D:/path/to/telaio')
   ```
+
+  `docker ps -a` and picking the id by hand works just as well.
 - The image is maintained at <https://github.com/marcopag90/java-maven-devcontainer>. It is deliberately generic — no
   editor, no agent, no personal configuration — so project-specific tooling belongs in this file, not in the image.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,8 +20,9 @@
     "source=telaio-dind,target=/var/lib/docker,type=volume",
 
     "source=telaio-m2,target=/home/vscode/.m2,type=volume",
-    // The JetBrains backend IDE weighs ~1.5 GB: without a volume it is
-    // downloaded again on every rebuild.
+    // Caches and indexes of the JetBrains backend — not the backend itself,
+    // which it deploys under /tmp. This is what spares a full re-index of the
+    // 14-module reactor after every recreate.
     "source=telaio-jetbrains,target=/home/vscode/.cache/JetBrains,type=volume",
     "source=telaio-gh,target=/home/vscode/.config/gh,type=volume"
   ],


### PR DESCRIPTION
Three claims in the dev container docs turned out to be wrong once a JetBrains-created container was actually inspected.

## 1. The `telaio-jetbrains` volume does not hold the backend IDE

Measured inside the live container:

- the backend runs as `java` (554 MB RSS, the container's Temurin 25) with its classpath under **`/tmp`**
- `/.jbdevcontainer/JetBrains/RemoteDev/dist`, the volume JetBrains mounts itself, was **empty** (32K)
- `~/.cache/JetBrains` held `IntelliJIdea2026.2` at 20K — project caches, which grow with indexing

So "the JetBrains backend IDE is ~1.5 GB" was the wrong reason for that volume. It is still worth having: what it saves is re-indexing a 14-module reactor after every recreate. Corrected in both `README.md` and the comment in `devcontainer.json`.

## 2. The documented cleanup command did not work for IntelliJ

The "one container at a time" note told you to filter on `devcontainer.local_folder` — a label only the `devcontainer` CLI and VS Code set. Verified against the running IntelliJ container:

```
label=devcontainer.local_folder=d:\development\projects\telaio          -> no match
label=com.intellij.devcontainer.sources.path=D:/development/projects/telaio -> c2169f0b3035
```

Note the difference in form: lowercased drive letter and backslashes for the CLI, original case and forward slashes for IntelliJ. Both variants are now documented, plus the obvious fallback of reading the id off `docker ps -a`.

This one mattered: the note exists precisely to stop two inner daemons from fighting over `telaio-dind`, and the command it gave you silently matched nothing.

## 3. The `portsAttributes` note was too strong

The JetBrains documentation does say only `label` is supported, but the `com.intellij.devcontainer.model` label on the container shows IDEA keeps the rest — `onAutoForward: silent` on 5432 and in `otherPortsAttributes` are both there (it filled in `notify` for 8080). Reworded to "the docs state only `label`; treat `onAutoForward` as reliable on VS Code and the CLI only" instead of claiming IDEA discards it.

## Also

Added what the client actually is, since it is not obvious and it changes what closing a window does: the backend is a JVM in the container, and the client is a **frame of your local IDE** rather than a separate application, so closing the local IDE ends the session while the container keeps running.

`devcontainer.json` still parses as JSONC. Docs and comments only, so `build` should report **skipped** — the first exercise of the `.devcontainer/**` ignore entry added in #16.