### PR TITLE
feat(showcase): adopt Spring Filter type-safe filter builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,35 @@ protected @Nullable FilterNode defaultFilter() {
     if (isPowerUser()) {        // role check via DalSecurityContextHelper — full code in the showcase
         return null;            // DEVELOPER/ADMIN see everything: drafts, archived, published
     }
-    return filterBuilder.field(propertyName(Article::getStatus))   // type-safe property reference
-        .equal(filterBuilder.input(ArticleStatus.PUBLISHED))
-        .get();                 // everyone else is silently scoped to PUBLISHED articles
+    return ArticleFilter.where(filterBuilder)   // compile-time generated type-safe builder
+        .status().equal(ArticleStatus.PUBLISHED)
+        .build();               // everyone else is silently scoped to PUBLISHED articles
 }
 ```
+
+`ArticleFilter` is generated at compile time by Spring Filter's
+[**type-safe filter builder**](https://github.com/turkraft/springfilter#type-safe-filter-builder): annotate the entity
+with `@Filterable` and the annotation processor emits an `<Entity>Filter` class with one method per field, so field
+names and operators are checked by the compiler. Both artifacts are version-managed by the Telaio BOM:
+
+```xml
+<dependency>
+    <groupId>com.turkraft.springfilter</groupId>
+    <artifactId>typesafe</artifactId>            <!-- runtime fluent steps -->
+</dependency>
+<dependency>
+    <groupId>com.turkraft.springfilter</groupId>
+    <artifactId>typesafe-processor</artifactId>  <!-- @Filterable + codegen -->
+    <scope>provided</scope>
+</dependency>
+```
+
+and the processor is registered via `maven-compiler-plugin`'s `annotationProcessorPaths` (see
+`telaio-showcase/pom.xml` for a working setup alongside Lombok). One caveat: the generated builders emit **Java field
+names** — when a `FilterNode` is sent over the wire (e.g. `DalClient.read(FilterNode, …)`), they must match the JSON
+names, so entities with `@JsonProperty` renames need care. For one-off expressions or classes you cannot annotate,
+the no-codegen alternative is `propertyName(Article::getStatus)` from telaio-introspection paired with the plain
+`filterBuilder` (see the [introspection module docs](docs/modules/introspection.md)).
 
 The full query grammar is in the [REST API reference](docs/rest-api.md); the `defaultFilter()`
 hook is covered in the [core module docs](docs/modules/core.md).

--- a/docs/modules/core.md
+++ b/docs/modules/core.md
@@ -137,7 +137,10 @@ Available hooks:
 - `defaultSort()` — Default sort order when none is requested
 - `defaultFilter()` — Implicit filter AND-combined with the request's `q` parameter and enforced on
   every operation addressing existing rows (list and by-id reads, updates, deletes — a hidden entity
-  behaves like a missing one; create payloads are not scoped by it)
+  behaves like a missing one; create payloads are not scoped by it). The returned `FilterNode` can be
+  built type-safely with the `@Filterable`-generated `<Entity>Filter` builder (Spring Filter's
+  `typesafe` + `typesafe-processor` artifacts) or manually via the injected `filterBuilder` — see the
+  [introspection module docs](./introspection.md) for when to use which
 
 ### 5. Validate Input Automatically
 

--- a/docs/modules/introspection.md
+++ b/docs/modules/introspection.md
@@ -25,38 +25,42 @@ Type introspection utilities enabling:
 The introspection module is used internally by Telaio but is also exposed as a public utility. Most common use:
 **refactor-safe property name resolution** in filter expressions and field lists.
 
-Instead of magic strings:
+There are two complementary ways to build a filter expression without magic strings — pick per situation:
 
-```java
-filterBuilder.field("status").equal("PUBLISHED")
-```
+1. **Generated type-safe builder** (Spring Filter's `typesafe` + `typesafe-processor` artifacts, both managed by the
+   Telaio BOM) — annotate the entity with `@Filterable` and use the compile-time-generated `<Entity>Filter` class.
+   Field names *and* operators are checked by the compiler. Prefer this when you own the entity and can annotate it.
+   This is what the showcase's `ArticleDalService` uses for its `defaultFilter()`:
 
-Use method references:
+   ```java
+   @Override
+   protected @Nullable FilterNode defaultFilter() {
+       Authentication auth = DalSecurityContextHelper.getCurrentAuthentication();
+       boolean isPowerUser = auth != null && auth.getAuthorities().stream()
+           .anyMatch(a -> UserRole.DEVELOPER.equals(a) || UserRole.ADMIN.equals(a));
+       if (isPowerUser) {
+           return null;
+       }
+       return ArticleFilter.where(filterBuilder)
+           .status().equal(ArticleStatus.PUBLISHED)
+           .build();
+   }
+   ```
 
-```java
-import static com.paganbit.telaio.introspection.PropertyNameResolver.propertyName;
+2. **`propertyName(...)` + the plain `FilterBuilder`** — no code generation; the method reference resolves the
+   property name, refactor-safe. Use it for one-off expressions, classes you cannot annotate, or dynamic field
+   selection:
 
-filterBuilder.field(propertyName(Article::getStatus))
-    .equal(filterBuilder.input(ArticleStatus.PUBLISHED))
-    .get()
-```
+   ```java
+   import static com.paganbit.telaio.introspection.PropertyNameResolver.propertyName;
 
-This is used in the showcase's `ArticleDalService` to define the `defaultFilter()`:
+   filterBuilder.field(propertyName(Article::getStatus))
+       .equal(filterBuilder.input(ArticleStatus.PUBLISHED))
+       .get()
+   ```
 
-```java
-@Override
-protected @Nullable FilterNode defaultFilter() {
-    Authentication auth = DalSecurityContextHelper.getCurrentAuthentication();
-    boolean isPowerUser = auth != null && auth.getAuthorities().stream()
-        .anyMatch(a -> UserRole.DEVELOPER.equals(a) || UserRole.ADMIN.equals(a));
-    if (isPowerUser) {
-        return null;
-    }
-    return filterBuilder.field(propertyName(Article::getStatus))
-        .equal(filterBuilder.input(ArticleStatus.PUBLISHED))
-        .get();
-}
-```
+Both produce a `FilterNode` carrying **Java property names**: fine anywhere server-side (the JPA converter handles
+them), but when sending a `FilterNode` over the wire via the REST client the names must match the JSON field names.
 
 ## No Configuration
 

--- a/docs/modules/jpa.md
+++ b/docs/modules/jpa.md
@@ -145,6 +145,8 @@ Available hooks (from `AbstractDal`):
 - `finalizeBeforeDelete/AfterDelete(I)` — Hooks around deletion (receive the entity id)
 - `defaultSort()` → `Sort` — Default sort order
 - `defaultFilter()` → `FilterNode?` — Implicit baseline filter (enforced on reads, updates and deletes).
+  Build the node type-safely with the `@Filterable`-generated `<Entity>Filter` builder or manually via the
+  injected `filterBuilder` (see the [introspection module docs](./introspection.md)).
   The delete pre-check runs inside the delete transaction and removes the loaded managed instance, so an
   entity with a JPA `@Version` attribute is race-proof (concurrent modification → `409 Conflict`); without
   `@Version` a theoretical intra-transaction window remains (known limitation)

--- a/docs/modules/showcase.md
+++ b/docs/modules/showcase.md
@@ -16,7 +16,7 @@ itself is compiled to and distributed as Java 21, so this is a property of the d
 | DAL               | Highlights                                                                             | Key File                 |
 |-------------------|----------------------------------------------------------------------------------------|--------------------------|
 | **announcements** | Baseline: no security, no audit, metrics disabled                                      | `AnnouncementDalService` |
-| **articles**      | Read-only (via `operations`), audit, default filter, role-based visibility             | `ArticleDalService`      |
+| **articles**      | Read-only (via `operations`), audit, default filter via type-safe builder (`@Filterable`), role-based visibility | `ArticleDalService`      |
 | **products**      | Full: auth + property-based RBAC, lifecycle hooks, multi-entity transactions           | `ProductDalService`      |
 | **employees**     | JsonView RBAC with hierarchical role visibility                                        | `EmployeeDalService`     |
 | **bulletins**     | Custom auth adapter (admin writes), metrics disabled                                   | `BulletinDalService`     |
@@ -219,7 +219,8 @@ curl -u developer:developer http://localhost:8080/dal/v1/products
 **Articles (read-only for non-power-users):**
 
 - `developer` / `admin`: See all (DRAFT, PUBLISHED, ARCHIVED)
-- `user`: See only PUBLISHED articles (implicit filter in `defaultFilter()`)
+- `user`: See only PUBLISHED articles (implicit filter in `defaultFilter()`, built with the
+  compile-time-generated `ArticleFilter` type-safe builder — `Article` is annotated `@Filterable`)
 
 **Products (write restricted):**
 

--- a/telaio-bom/pom.xml
+++ b/telaio-bom/pom.xml
@@ -110,6 +110,16 @@
                 <version>${turkraft-springfilter.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.turkraft.springfilter</groupId>
+                <artifactId>typesafe</artifactId>
+                <version>${turkraft-springfilter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.turkraft.springfilter</groupId>
+                <artifactId>typesafe-processor</artifactId>
+                <version>${turkraft-springfilter.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.springdoc</groupId>
                 <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
                 <version>${springdoc-openapi-starter-webmvc-ui.version}</version>

--- a/telaio-showcase/pom.xml
+++ b/telaio-showcase/pom.xml
@@ -54,6 +54,16 @@
             <groupId>com.paganbit</groupId>
             <artifactId>telaio-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.turkraft.springfilter</groupId>
+            <artifactId>typesafe</artifactId>
+        </dependency>
+        <!-- Provides @Filterable (SOURCE retention) to entity sources; provided = compile-only. -->
+        <dependency>
+            <groupId>com.turkraft.springfilter</groupId>
+            <artifactId>typesafe-processor</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <!-- The blocking REST client at compile scope: the app is a client of its own DAL API
              (see SupportTicketDalService + telaio.rest-client.connections.self). -->
         <dependency>
@@ -108,6 +118,19 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- Appends to the parent-managed processor path list (Lombok stays first). -->
+                    <annotationProcessorPaths combine.children="append">
+                        <path>
+                            <groupId>com.turkraft.springfilter</groupId>
+                            <artifactId>typesafe-processor</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>

--- a/telaio-showcase/src/main/java/com/paganbit/telaio/showcase/dal/announcement/Announcement.java
+++ b/telaio-showcase/src/main/java/com/paganbit/telaio/showcase/dal/announcement/Announcement.java
@@ -1,5 +1,6 @@
 package com.paganbit.telaio.showcase.dal.announcement;
 
+import com.turkraft.springfilter.typesafe.Filterable;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @NoArgsConstructor
+@Filterable
 @Entity
 @Table(name = "announcements")
 public class Announcement {

--- a/telaio-showcase/src/main/java/com/paganbit/telaio/showcase/dal/article/Article.java
+++ b/telaio-showcase/src/main/java/com/paganbit/telaio/showcase/dal/article/Article.java
@@ -1,5 +1,6 @@
 package com.paganbit.telaio.showcase.dal.article;
 
+import com.turkraft.springfilter.typesafe.Filterable;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Min;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @NoArgsConstructor
+@Filterable
 @Entity
 @Table(name = "articles")
 @EntityListeners(AuditingEntityListener.class)

--- a/telaio-showcase/src/main/java/com/paganbit/telaio/showcase/dal/article/ArticleDalService.java
+++ b/telaio-showcase/src/main/java/com/paganbit/telaio/showcase/dal/article/ArticleDalService.java
@@ -10,8 +10,6 @@ import com.turkraft.springfilter.parser.node.FilterNode;
 import org.jspecify.annotations.Nullable;
 import org.springframework.security.core.Authentication;
 
-import static com.paganbit.telaio.introspection.PropertyNameResolver.propertyName;
-
 /**
  * <h2>Use case — a read-only resource via per-operation exposure, with audit and an implicit read filter</h2>
  * <p>
@@ -36,7 +34,12 @@ import static com.paganbit.telaio.introspection.PropertyNameResolver.propertyNam
  * own {@code q} filter on <em>every</em> read (see {@code AbstractDal#combineWithDefaultFilter}). Here it
  * implements row-level visibility: non-power-users (anyone who is not {@code DEVELOPER}/{@code ADMIN}) can
  * only ever see {@code PUBLISHED} articles, regardless of the filter they send. Returning {@code null}
- * disables the constraint for power-users, who see drafts and archived articles too.
+ * disables the constraint for power-users, who see drafts and archived articles too. The constraint is
+ * built with {@code ArticleFilter}, the type-safe builder generated at compile time from the
+ * {@code @Filterable} annotation on {@link Article} (Turkraft {@code typesafe-processor}). Compared to the
+ * equivalent manual {@code filterBuilder.field(propertyName(Article::getStatus))} pairing — which is
+ * already refactor-safe on the field name — the generated builder also type-checks the operator and its
+ * value against the field's type.
  */
 @DalService(name = "articles", operations = {DalOperationType.READ, DalOperationType.READ_ONE})
 @DalAudit(operations = {DalOperationType.READ, DalOperationType.READ_ONE})
@@ -46,12 +49,12 @@ public class ArticleDalService extends JpaDal<Article, Long> {
     protected @Nullable FilterNode defaultFilter() {
         Authentication auth = DalSecurityContextHelper.getCurrentAuthentication();
         boolean isPowerUser = auth != null && auth.getAuthorities().stream()
-            .anyMatch(a -> UserRole.DEVELOPER.equals(a) || UserRole.ADMIN.equals(a));
+                .anyMatch(a -> UserRole.DEVELOPER.equals(a) || UserRole.ADMIN.equals(a));
         if (isPowerUser) {
             return null;
         }
-        return filterBuilder.field(propertyName(Article::getStatus))
-            .equal(filterBuilder.input(ArticleStatus.PUBLISHED))
-            .get();
+        return ArticleFilter.where(filterBuilder)
+                .status().equal(ArticleStatus.PUBLISHED)
+                .build();
     }
 }

--- a/telaio-showcase/src/test/java/com/paganbit/telaio/showcase/it/TelaioClientRoundTripIT.java
+++ b/telaio-showcase/src/test/java/com/paganbit/telaio/showcase/it/TelaioClientRoundTripIT.java
@@ -8,9 +8,13 @@ import com.paganbit.telaio.rest.client.blocking.TelaioRestClient;
 import com.paganbit.telaio.rest.client.blocking.v1.DalClient;
 import com.paganbit.telaio.rest.client.exception.DalClientNotFoundException;
 import com.paganbit.telaio.rest.client.exception.DalClientValidationException;
+import com.paganbit.telaio.showcase.dal.announcement.AnnouncementFilter;
+import com.turkraft.springfilter.builder.FilterBuilder;
+import com.turkraft.springfilter.parser.node.FilterNode;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.client.support.BasicAuthenticationInterceptor;
 import org.springframework.web.client.RestClient;
 
@@ -47,6 +51,9 @@ class TelaioClientRoundTripIT extends AbstractShowcaseIT {
 
     private DalClient<Announcement, Long> announcements;
     private DalClient<Translation, TranslationId> translations;
+
+    @Autowired
+    private FilterBuilder filterBuilder;
 
     @BeforeEach
     void setUpClient() {
@@ -116,8 +123,15 @@ class TelaioClientRoundTripIT extends AbstractShowcaseIT {
         announcements.create(new Announcement(null, marker + "-b", "Second.", "INFO"));
         announcements.create(new Announcement(null, marker + "-a", "First.", "INFO"));
 
+        // Built with the @Filterable-generated type-safe builder instead of a raw q string.
+        // The builder emits Java field names; on the wire they must match the JSON names, which
+        // holds for Announcement (no @JsonProperty renames) but not for every entity.
+        FilterNode filter = AnnouncementFilter.where(filterBuilder)
+            .title().startsWith(marker)
+            .build();
+
         DalPage<Announcement> page = announcements.read(
-            "title ~ '" + marker + "*'",
+            filter,
             DalPageRequest.of(0, 10).withSort(DalSort.asc("title")));
 
         assertThat(page.page().totalElements()).isEqualTo(2);


### PR DESCRIPTION
﻿## Summary

Integrates [Spring Filter's type-safe filter builder](https://github.com/turkraft/springfilter#type-safe-filter-builder) as **consumer enablement** — the classic `FilterBuilder` was already wired end-to-end (injected into every `AbstractDal`, `DalClient.read(FilterNode, ...)` overload on the client), so this adds the missing compile-time-safe layer without touching any library module.

- **telaio-bom**: manages `com.turkraft.springfilter:typesafe` and `:typesafe-processor` at the existing `${turkraft-springfilter.version}` (4.0.6). BOM stays parentless, literal version untouched.
- **telaio-showcase**:
  - `typesafe` (compile) + `typesafe-processor` (provided — carries the SOURCE-retention `@Filterable`) dependencies; processor registered via `annotationProcessorPaths combine.children="append"` so Lombok stays first in the parent-managed path list.
  - `Article` and `Announcement` annotated `@Filterable` -> compile-time-generated `ArticleFilter`/`AnnouncementFilter`.
  - **Server-side demo**: `ArticleDalService.defaultFilter()` rewritten with `ArticleFilter.where(filterBuilder).status().equal(PUBLISHED).build()` — verified semantically identical to the previous manual builder (same `FilterNode`).
  - **Client-side demo**: `TelaioClientRoundTripIT.filteredAndSortedPageRead()` replaces the raw `q` string with `AnnouncementFilter...startsWith(marker)` -> the existing frozen `DalClient.read(FilterNode, ...)` overload. The value now travels through an escaped `InputNode` instead of string concatenation.
- **Docs**: README filtering section (coordinates + caveat), `docs/modules/{core,jpa,showcase}.md`, and `docs/modules/introspection.md` restructured as "two complements" (generated builder vs `propertyName(...)` + manual builder).

### Caveat (documented)

Generated builders emit **Java field names**; when a `FilterNode` is sent over the wire they must match the JSON names — true for `Article`/`Announcement`, not for entities with `@JsonProperty` renames (e.g. showcase `Product`).

## Test plan

- [x] `mvn -pl telaio-showcase -am clean test-compile` — `ArticleFilter`/`AnnouncementFilter` generated under `target/generated-sources/annotations`
- [x] `mvn -pl telaio-showcase verify -Dit.test=TelaioClientRoundTripIT` — 5/5 green (Testcontainers)
- [x] `mvn clean install` — full reactor green, 59 showcase ITs passing
- [x] Review panel (java-architect, code-reviewer, microservices-architect, documentation-engineer): no blocking issues; Javadoc nit applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
