### PR TITLE
feat(security): reject q= filters on fields the principal cannot read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   filter the entity cannot honour, `JsonPropertyPathResolver.resolveJavaPath` reporting the first
   unresolvable segment of a field path, and `FilterNodes.fieldNodes` collecting the field references of a
   parsed filter.
+- Security: field-level RBAC now governs the `q=` filter too. `DalRbacAdapter.canFilterOn(fieldPath, auth)`
+  (new `default` hook, pass-through) is asked by `DalSecurityInterceptor` for every field a read filter references,
+  before the read runs; a field the principal cannot read is rejected with the same generic 400
+  (`"Invalid filter expression"`) as an unknown field — closing the inference channel where a hidden value
+  (e.g. `cost_price`) could be worked out from the narrowed page. Both built-in adapters implement the same rule —
+  a field is filterable exactly when it appears in the read response: `PropertyBasedDalRbacAdapter` requires a
+  serialized property granted in the read readable map (exactly or through a granted descendant);
+  `JsonViewDalRbacAdapter` requires the active read view on every declared property of the path, map values
+  included. Both resolve the path under the wire name and the Java name of the property alike. Server-side
+  `defaultFilter()`s are not affected. The
+  rejection is raised as `DalFilterFieldNotReadableException` (core; a `DalInvalidFilterException`), which
+  `telaio-audit`'s `SecurityDalAuditOutcomeClassifier` records as a **DENIED** event. `JsonPropertyPathResolver`'s
+  path-walking rules (`isReferenceKeySegment`, `unwrapElements`, `isOpaque`, `isLeaf`) are now public.
 
 ### 🐞 Bug Fixes
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,8 +131,9 @@ sequenceDiagram
 2. **Exposure check** (step 1) returns 404 or 405 for non-exposed operations before reaching the DAL.
 3. **Audit denied** (step 2) records failed authorization attempts.
 4. **Security** (step 3) runs the `DalAuthAdapter` to check if the principal can perform the operation, then applies
-   the `DalRbacAdapter` to filter input/output fields by role — both happen inside the single
-   `DalSecurityInterceptor` (RBAC is not a separate interceptor in the chain).
+   the `DalRbacAdapter` to filter input/output fields by role and to reject a filter that references a field the
+   principal cannot read — all inside the single `DalSecurityInterceptor` (RBAC is not a separate interceptor in the
+   chain).
 5. **Web operation** (step 4) calls the underlying `Dal` method with the filtered input.
 
 ## Per-Request Adapter Chain (REST Boundary)
@@ -140,7 +141,8 @@ sequenceDiagram
 When a REST request arrives at `DalRestApiV1Controller`, it flows through the **web adapter chain**. This chain is
 responsible for exposure control, security checks, and RBAC filtering. Note that RBAC is not a separate interceptor:
 the `DalSecurityInterceptor` first checks authorization via the `DalAuthAdapter`, then applies the `DalRbacAdapter`
-to filter fields — the diagram shows them as distinct steps only to make the logical order visible:
+to check the filter's field references and to filter fields — the diagram shows them as distinct steps only to make
+the logical order visible:
 
 ```mermaid
 graph TD

--- a/docs/modules/security.md
+++ b/docs/modules/security.md
@@ -28,12 +28,12 @@ operations. It requires Spring Security on the classpath.
 
 ### RBAC (Field-Level)
 
-| Type                          | Purpose                                                                                                                                                                                  |
-|-------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DalRbacAdapter<T>`           | SPI: `Map<String,Object> filterInput(DalOperationType, Map<String,Object>, Authentication)` and `Object filterOutput(DalOperationType, T, Authentication)` (both `default` pass-through) |
-| `NoopDalRbacAdapter`          | Built-in: no filtering (default when `@DalSecurity` is absent or omitted)                                                                                                                |
-| `PropertyBasedDalRbacAdapter` | Built-in: abstract base class defining readable/writable fields per role via property name maps                                                                                          |
-| `JsonViewDalRbacAdapter`      | Built-in: abstract base class delegating to Jackson `@JsonView` annotations on the entity                                                                                                |
+| Type                          | Purpose                                                                                                                                                                                                                                                                                                     |
+|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DalRbacAdapter<T>`           | SPI: `Map<String,Object> filterInput(DalOperationType, Map<String,Object>, Authentication)`, `Object filterOutput(DalOperationType, T, Authentication)` and `boolean canFilterOn(String fieldPath, Authentication)` — may the principal reference this field in a `q=` filter? (all `default` pass-through) |
+| `NoopDalRbacAdapter`          | Built-in: no filtering (default when `@DalSecurity` is absent or omitted)                                                                                                                                                                                                                                   |
+| `PropertyBasedDalRbacAdapter` | Built-in: abstract base class defining readable/writable fields per role via property name maps                                                                                                                                                                                                             |
+| `JsonViewDalRbacAdapter`      | Built-in: abstract base class delegating to Jackson `@JsonView` annotations on the entity                                                                                                                                                                                                                   |
 
 ### Support
 
@@ -49,6 +49,7 @@ operations. It requires Spring Security on the classpath.
 **No `@DalSecurity` annotation:**
 
 ```java
+
 @DalService(name = "announcements")
 public class AnnouncementDalService extends JpaDal<Announcement, Long> {
 }
@@ -59,6 +60,7 @@ public class AnnouncementDalService extends JpaDal<Announcement, Long> {
 **Bare `@DalSecurity` annotation:**
 
 ```java
+
 @DalService(name = "bulletins")
 @DalSecurity
 public class BulletinDalService extends JpaDal<Bulletin, Long> {
@@ -72,6 +74,7 @@ public class BulletinDalService extends JpaDal<Bulletin, Long> {
 Implement `DalAuthAdapter` to control which operations each role can perform:
 
 ```java
+
 @Component
 public class ProductAuthAdapter implements DalAuthAdapter<Long> {
 
@@ -114,6 +117,7 @@ public class ProductAuthAdapter implements DalAuthAdapter<Long> {
 Then wire it:
 
 ```java
+
 @DalService(name = "products")
 @DalSecurity(authAdapterClass = ProductAuthAdapter.class)
 public class ProductDalService extends JpaDal<Product, Long> {
@@ -122,9 +126,12 @@ public class ProductDalService extends JpaDal<Product, Long> {
 
 ### Strategy 2: Field-Level RBAC via Property Maps
 
-Extend `PropertyBasedDalRbacAdapter` to define readable/writable fields per role:
+Extend `PropertyBasedDalRbacAdapter` to define readable/writable fields per role. The readable map also decides which
+fields a `q=` filter may reference: a field pruned from the response is rejected as a filter criterion with the same 400
+as an unknown field (whether spelled by its wire name or its Java name).
 
 ```java
+
 @Component
 public class ProductRbacAdapter extends PropertyBasedDalRbacAdapter<Product> {
 
@@ -155,6 +162,7 @@ public class ProductRbacAdapter extends PropertyBasedDalRbacAdapter<Product> {
 Wire it:
 
 ```java
+
 @DalService(name = "products")
 @DalSecurity(
     authAdapterClass = ProductAuthAdapter.class,
@@ -172,7 +180,8 @@ When a USER requests `PATCH /dal/v1/products/1` with `{ "costPrice": 50 }`, the 
 
 ### Strategy 3: Field-Level RBAC via Jackson `@JsonView`
 
-Use `@JsonView` annotations on the entity for hierarchical role-based visibility:
+Use `@JsonView` annotations on the entity for hierarchical role-based visibility. The read view also governs the `q=`
+filter: only properties visible in the view may be referenced (a property with no `@JsonView` is never filterable):
 
 ```java
 public interface EmployeeView {
@@ -206,6 +215,7 @@ public class Employee {
 Extend `JsonViewDalRbacAdapter` to map roles to views:
 
 ```java
+
 @Component
 public class EmployeeRbacAdapter extends JsonViewDalRbacAdapter<Employee> {
 
@@ -228,6 +238,7 @@ public class EmployeeRbacAdapter extends JsonViewDalRbacAdapter<Employee> {
 Wire it:
 
 ```java
+
 @DalService(name = "employees")
 @DalSecurity(
     authAdapterClass = PermitAllDalAuthAdapter.class,

--- a/docs/modules/showcase.md
+++ b/docs/modules/showcase.md
@@ -346,8 +346,7 @@ telaio-showcase/
 │   └── role/
 │       └── UserRole.java
 ├── src/main/resources/
-│   ├── application.yaml
-│   └── application.properties (only the MongoTemplate log level — see the comment in the file)
+│   └── application.yaml
 ├── src/test/java/
 │   ├── com/paganbit/telaio/showcase/
 │   │   ├── TelaioShowcaseApplicationTests.java

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,13 +45,14 @@ Residuals:
   `MongoTemplate` DEBUG logging on every consumer — **removed upstream in 4.1.0 (2026-08-29, #527)**. The showcase's
   own `application.properties` override (the only way to neutralize it: at the same location `.properties` takes
   precedence over `.yaml`, and Boot loads a single `classpath:/application.properties` — the first on the classpath)
-  is now redundant and can be dropped. telaio-mongo deliberately never shipped an `application.properties` of its
-  own — it would be the same anti-pattern.
+  became redundant and was **dropped on 2026-08-30**. telaio-mongo deliberately never shipped an
+  `application.properties` of its own — it would be the same anti-pattern.
 
 ## 3. Turkraft mongo functional gaps (document-only for now)
 
 - The `mongo-language` artifact is **empty** — the Mongo filter function vocabulary is only `size` / `today`
-  beyond the standard operators, versus JPA's ~55 processors. Candidate for an upstream issue.
+  beyond the standard operators, versus JPA's ~55 processors. Documented in [modules/mongo.md](modules/mongo.md);
+  filing upstream issues is out of Telaio's scope (decided 2026-08-30).
 - **Done (2026-08-28, shipped in Turkraft 4.1.0):** temporal comparisons now work — filter values used to pass
   through `Document.parse`, so date literals became plain strings and never matched BSON `Date` fields. Fixed upstream
   by this repo's maintainer ([springfilter#524](https://github.com/turkraft/springfilter/issues/524)): the `mongo`
@@ -145,27 +146,52 @@ no user-facing docs):
 - Latent gap fixed: library modules run surefire only, so `JsonAwareFilterSpecificationConverterIT` had never
   executed — renamed `*IntegrationTest`.
 
-**Turkraft findings (upstream candidates; #527 shipped in 4.1.0 without them):** (1) JPA
-`FilterExpressionTransformer.transformInput` swallows `ConversionFailedException` and falls back to the raw literal,
-turning a bad literal into a SQL `CAST` failing at execution — a fork rethrow was tried and **dropped** (2026-08-29):
-telaio keeps unconvertible literals as a uniform 500 instead; (2) multi-pattern like `f ~ ['a','b']` uses raw SQL patterns on JPA (no `*`
-translation, no `%…%` wrap) but `*` regexes on Mongo; (3) `countDistinct` has a definition but no JPA processor;
-(4) `locate()` requires all three arguments although the README shows two; (5) Mongo embeds string literals raw in
-the `$expr` (`q=name:'$code'` compares two fields) — `{$literal: …}` would be safer; (6) under an `Object`-typed
-(schemaless) property a numeric literal does not match on Mongo (`payload.nested.level : 2` → no rows, while
-`payload.nested.tag : 'deep'` matches — the target type is unresolvable, literal handling to be investigated upstream).
-
-**Residual.** Write-only (`@JsonProperty(access = WRITE_ONLY)`) and `@JsonIgnore`d properties remain filterable by
-name (pre-existing behaviour, kept so default filters and in-process callers do not break) — see item 8.
+The backend-specific Turkraft behaviours observed while building the suites (multi-pattern like semantics, `countDistinct`
+without a JPA processor, `locate()` arity, raw string literals in `$expr`, numeric literals under an `Object`-typed
+property on Mongo) are pinned by the two ITs as the behaviour of the version in use; reporting them upstream is out of
+Telaio's scope (decided 2026-08-30).
 
 ## 8. Field-level authorization of `q=` filters
 
-**Open.** Field-level RBAC prunes *output* (`DalRbacAdapter.filterOutput`), but nothing inspects the `FieldNode`s of a
-filter: a principal with READ can filter on a property the adapter hides from them (`cost_price > 100`, bisection) and
-infer its value from the narrowed page. Surfaced by the security review of item 7 (2026-08-28). Candidate design: a
-`DalRbacAdapter` hook receiving the referenced JSON paths (after the JSON-name rewrite), applied in
-`DalSecurityInterceptor` before the read, rejecting references outside the role's readable set with
-`DalInvalidFilterException` (same 400 as an unknown field, so nothing is disclosed).
+**Done (2026-08-30, branch `feature/filter-field-rbac`).** Field-level RBAC pruned *output* only
+(`DalRbacAdapter.filterOutput`); nothing inspected the `FieldNode`s of a filter, so a principal with READ could filter
+on a property the adapter hides from them (`cost_price > 100`, bisection) and infer its value from the narrowed page.
+Surfaced by the security review of item 7 (2026-08-28).
+
+Delivered: `DalRbacAdapter.canFilterOn(String fieldPath, Authentication)` — a `default` pass-through hook (custom
+adapters stay source-compatible; `NoopDalRbacAdapter` accepts everything) — asked by `DalSecurityInterceptor` for every
+field of the caller's filter (`FilterNodes.fieldNodes`), after the operation-level check (a denied read stays a 403) and
+before `proceed()`; a denied field throws `DalFilterFieldNotReadableException` (a `DalInvalidFilterException`
+specialisation) → the same generic 400 as an unknown field on the wire, while `SecurityDalAuditOutcomeClassifier`
+records it as a **DENIED** audit event (probing hidden fields is an authorization signal). The path is checked *as
+written* (wire name or Java name — both are accepted by the backends, so string-matching
+would be a bypass) and each adapter applies the rule of its own output filtering: `PropertyBasedDalRbacAdapter`
+resolves the path to Java names (`JsonPropertyPathResolver.resolveJavaPath`) and requires a *serialized* property
+granted in the read readable map — exact or through a granted descendant, like `prune`; keys below a `Map` property
+and `$id/$ref/$db` reference accessors are not serialized properties and are never filterable. `JsonViewDalRbacAdapter`
+walks the serialization-view properties (keyed by JSON and Java name) requiring the active read view on every declared
+property, descending into the value bean of a `Map` (Jackson applies the view there too), and stops only at
+`Object`/`JsonNode` values and `$id/$ref/$db`. The shared walking rules (`isReferenceKeySegment`, `unwrapElements`,
+`isOpaque`, `isLeaf`) were made public on `JsonPropertyPathResolver` so the two walkers cannot drift. The DAL's own
+`defaultFilter()` is combined inside `AbstractDal`, after the interceptor, so server-side filters are never subject to
+the check. This also absorbs the former residual of item 7: write-only (`@JsonProperty(access = WRITE_ONLY)`) and
+`@JsonIgnore`d properties stay resolvable by Java name (so default filters and in-process callers keep working), but
+behind a field-level RBAC adapter they are filterable only if the adapter grants them (`JsonView`: never — they are
+absent from the serialization view; property maps: only when listed in the readable map). Covered by
+`DalSecurityInterceptorTest`,
+`PropertyBasedDalRbacAdapterTest`, `JsonViewDalRbacAdapterTest`, `NoopDalRbacAdapterTest` and end-to-end by the showcase
+`RbacFilterFieldIT` (`products`/`cost_price` for property maps, `employees`/`salary` for `@JsonView`).
+
+## 10. Field-level authorization of `sort=`
+
+**Open.** Surfaced by the security review of item 8 (2026-08-30): the `Pageable` sort is passed straight to the
+backend (`JpaDal`/`MongoDal` `findAll(spec, pageable)`) and nothing in `DalSecurityInterceptor` inspects
+`pageable.getSort()`. A principal who cannot read `costPrice` can still request `products?sort=costPrice,desc&size=1`
+and learn the *relative* order of the hidden values (which product has the highest margin), plus an existence oracle
+(hidden-but-existing property → 200, unknown property → backend error). Candidate design: in the READ branch, ask
+`DalRbacAdapter.canFilterOn(order.getProperty(), auth)` for every `Sort.Order` (the rule is identical — a sort key the
+principal cannot read) and reject with the same generic 400; check how each backend resolves sort property names
+(wire vs Java) first, so the check canonicalises the way the backend does.
 
 ## 9. Reject filters on serialized-but-not-persisted properties (JPA vs Mongo)
 

--- a/docs/security-guide.md
+++ b/docs/security-guide.md
@@ -23,6 +23,59 @@ Telaio enforces security at **four distinct layers**:
 
 A request reaches each layer only if the earlier layers pass.
 
+## The Running Example: `Product`
+
+Every `products` example in this guide builds on one entity — the showcase's `Product`, trimmed to what matters here.
+Given the entity:
+
+```java
+@Entity
+public class Product {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @NotBlank
+    private String name;
+
+    private String description;
+
+    @NotNull
+    private BigDecimal price;
+
+    /** Sensitive: what the product costs us. Renamed on the wire. */
+    @JsonProperty("cost_price")
+    private BigDecimal costPrice;
+
+    /** Derived from price and costPrice by the DAL hooks — never accepted from the client. */
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private BigDecimal marginPercentage;
+
+    /** Not persisted, computed after every read/write, still serialized. */
+    @Transient
+    private BigDecimal profit;
+
+    private String sku;
+
+    /** Sensitive: internal warehouse code. Renamed on the wire. */
+    @JsonProperty("internal_sku")
+    private String internalSku;
+
+    private String category;
+
+    private Boolean available;
+}
+```
+
+Three traits of this entity drive the examples that follow:
+
+- **Sensitive fields with wire renames.** `costPrice` and `internalSku` must stay hidden from most roles, and both
+  carry a `@JsonProperty` rename (`cost_price`, `internal_sku`) — so the wire name and the Java name differ, which the
+  RBAC examples have to handle.
+- **Computed fields.** `marginPercentage` and `profit` are produced by the DAL, readable but never writable.
+- **Roles.** The principals are the showcase's `UserRole.DEVELOPER`, `ADMIN` and `USER` (set up in Layer 2).
+
 ## Layer 1: Exposure (Structural Boundaries)
 
 **Purpose**: Hide operations from the API surface entirely.
@@ -193,8 +246,8 @@ to the client.
 
 **Mechanism**: `DalRbacAdapter<T>`
 
-Even if a principal is authorized to CREATE a PRODUCT, the RBAC adapter might remove sensitive fields like `costPrice`
-from the request, or hide them from the response.
+Even if a principal is authorized to CREATE a `Product`, the RBAC adapter might remove sensitive fields like
+`costPrice` from the request, or hide them from the response.
 
 ### Contract
 
@@ -203,14 +256,35 @@ public interface DalRbacAdapter<T> {
     Map<String, Object> filterInput(DalOperationType operation, Map<String, Object> input, Authentication auth);
 
     Object filterOutput(DalOperationType operation, T entity, Authentication auth);
+
+    boolean canFilterOn(String fieldPath, Authentication auth);
 }
 ```
+
+### Filters
+
+Hiding a field from the response is not enough: a principal who cannot see `costPrice` could still send
+`q=cost_price>100` and work out its value from the rows that come back. `canFilterOn` closes that gap — the
+`DalSecurityInterceptor` asks it for every field the caller's filter references, *before* the read runs, and rejects
+the request with the same generic `400 "Invalid filter expression"` as an unknown field, so the filter cannot be used
+to probe which hidden properties exist.
+
+Both built-in adapters implement the same rule: **a field is filterable exactly when it appears in the read
+response**. `PropertyBasedDalRbacAdapter` checks the read readable map, `JsonViewDalRbacAdapter` the active read view;
+the fine print for nested paths and `Map` properties is in each adapter's Javadoc. The field path is checked as
+written — wire name or Java name — so a rename offers no bypass. Server-side default filters (`defaultFilter()`) are
+combined inside the DAL, after this check, and are never subject to it. With `telaio-audit` enabled, a rejected filter
+field is recorded as a **DENIED** event (like an authorization failure), so repeated probing of hidden fields is
+visible in the audit trail even though the client only sees a generic 400.
+
+> **Known gap:** the `sort=` parameter is not yet subject to the same check — a principal can order a page by a hidden
+> property and learn the relative order of its values. Tracked as roadmap item 10.
 
 ### Strategy 1: Property-Based RBAC
 
 Use `PropertyBasedDalRbacAdapter` for a simple role → field set mapping.
 
-**From the showcase** (`ProductRbacAdapter.java`):
+**From the showcase** (`ProductRbacAdapter.java`, for the `Product` entity defined at the top of this guide):
 
 ```java
 @Component
@@ -294,15 +368,9 @@ public class ProductRbacAdapter extends PropertyBasedDalRbacAdapter<Product> {
 **Derived fields**: Fields like `marginPercentage` are computed and only readable (not in the writable map). They appear
 in responses but a client cannot set them.
 
-**JSON property names**: The adapter references Java property names (`Product::getCostPrice`), but the framework
-translates to JSON names automatically. If your entity has:
-
-```java
-@JsonProperty("cost_price")
-private Double costPrice;
-```
-
-The adapter still uses `propertyName(Product::getCostPrice)`, and the translation to `cost_price` is transparent.
+**JSON property names**: The adapter references Java property names (`Product::getCostPrice`) even though the entity
+declares `@JsonProperty("cost_price")` — the framework translates to the JSON wire name automatically, so the rename is
+transparent to the adapter.
 
 ### Strategy 2: JsonView-Based RBAC
 
@@ -449,7 +517,8 @@ and passes it to your adapters.
    filtering.
 
 4. **Test your adapters**: Write unit tests for your `DalAuthAdapter` and `DalRbacAdapter` to ensure the filtering is
-   correct.
+   correct. If you write a `DalRbacAdapter` from scratch, implement `canFilterOn` too — the default accepts every
+   field, which leaves hidden values open to inference through `q=`.
 
 5. **Log authorization denials**: Telaio automatically logs them to `telaio-audit`, so configure your log aggregator to
    flag denials.
@@ -459,27 +528,8 @@ and passes it to your adapters.
 
 ## Example: Full Security Setup
 
-**Entity**:
-
-```java
-@Entity
-public class Product {
-    @Id
-    @GeneratedValue
-    private Long id;
-
-    @NotBlank
-    private String name;
-
-    @NotNull
-    private Double price;
-
-    @JsonProperty("cost_price")
-    private Double costPrice;
-
-    private String category;
-}
-```
+Putting the layers together for the `Product` entity defined at the top of this guide (the RBAC maps below use a
+reduced field set to keep the example readable).
 
 **Authorization adapter** (the showcase's actual `ProductAuthAdapter`: admins and developers can write;
 everyone can read):

--- a/telaio-audit/src/main/java/com/paganbit/telaio/audit/event/SecurityDalAuditOutcomeClassifier.java
+++ b/telaio-audit/src/main/java/com/paganbit/telaio/audit/event/SecurityDalAuditOutcomeClassifier.java
@@ -1,5 +1,6 @@
 package com.paganbit.telaio.audit.event;
 
+import com.paganbit.telaio.core.exception.DalFilterFieldNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 
 /**
@@ -9,7 +10,10 @@ import org.springframework.security.access.AccessDeniedException;
  * conflict, error) exactly like {@link DefaultDalAuditOutcomeClassifier}.
  *
  * <p>Telaio's own {@code DalAccessDeniedException} extends {@link AccessDeniedException}, so DAL
- * authorization failures are covered without a dependency on the security module.</p>
+ * authorization failures are covered without a dependency on the security module. A read filter
+ * referencing a field the principal may not read ({@link DalFilterFieldNotReadableException}) is a
+ * denied attempt too: on the wire it is a plain client fault, but repeated probing of hidden fields is
+ * exactly the signal an audit trail exists for.</p>
  *
  * @author Marco Pagan
  * @since 1.0.0
@@ -20,7 +24,7 @@ public class SecurityDalAuditOutcomeClassifier implements DalAuditOutcomeClassif
 
     @Override
     public DalAuditOutcome classify(Throwable failure) {
-        return failure instanceof AccessDeniedException
+        return failure instanceof AccessDeniedException || failure instanceof DalFilterFieldNotReadableException
             ? DalAuditOutcome.DENIED
             : fallback.classify(failure);
     }

--- a/telaio-audit/src/test/java/com/paganbit/telaio/audit/event/DalAuditOutcomeClassifierTest.java
+++ b/telaio-audit/src/test/java/com/paganbit/telaio/audit/event/DalAuditOutcomeClassifierTest.java
@@ -2,6 +2,7 @@ package com.paganbit.telaio.audit.event;
 
 import com.paganbit.telaio.core.exception.DalEntityNotFoundException;
 import com.paganbit.telaio.core.exception.DalEntityValidationException;
+import com.paganbit.telaio.core.exception.DalFilterFieldNotReadableException;
 import com.paganbit.telaio.core.exception.DalInvalidFilterException;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -63,6 +64,16 @@ class DalAuditOutcomeClassifierTest {
 
         assertThat(defaultClassifier.classify(failure)).isEqualTo(DalAuditOutcome.VALIDATION);
         assertThat(securityClassifier.classify(failure)).isEqualTo(DalAuditOutcome.VALIDATION);
+    }
+
+    @Test
+    void filterOnNonReadableField_shouldBeDenied_forSecurity_andValidation_forDefault() {
+        // Same wire answer as an unknown field, but for audit it is an authorization signal: probing
+        // hidden fields through q= is recorded as DENIED where an authorization concept exists.
+        DalFilterFieldNotReadableException probing = new DalFilterFieldNotReadableException("cost_price");
+
+        assertThat(securityClassifier.classify(probing)).isEqualTo(DalAuditOutcome.DENIED);
+        assertThat(defaultClassifier.classify(probing)).isEqualTo(DalAuditOutcome.VALIDATION);
     }
 
     @Test

--- a/telaio-core/src/main/java/com/paganbit/telaio/core/exception/DalFilterFieldNotReadableException.java
+++ b/telaio-core/src/main/java/com/paganbit/telaio/core/exception/DalFilterFieldNotReadableException.java
@@ -1,0 +1,26 @@
+package com.paganbit.telaio.core.exception;
+
+/**
+ * Exception thrown when a well-formed filter references a field the current principal is not allowed
+ * to read.
+ *
+ * <p>A specialization of {@link DalInvalidFilterException} that is <em>deliberately indistinguishable on
+ * the wire</em> from an unknown field (same generic client fault, same body), so a filter cannot be used
+ * to learn whether a hidden property exists — while remaining distinguishable in-process: repeated
+ * probing of hidden fields is an authorization signal, and audit records it as a denied attempt rather
+ * than a plain validation failure.</p>
+ *
+ * @author Marco Pagan
+ * @since 1.2.0
+ */
+public class DalFilterFieldNotReadableException extends DalInvalidFilterException {
+
+    /**
+     * Creates the exception for a filter field the current principal is not allowed to read.
+     *
+     * @param path the complete field path as written in the filter (never a literal value)
+     */
+    public DalFilterFieldNotReadableException(String path) {
+        super("Filter field '%s' is not readable by the current principal".formatted(path));
+    }
+}

--- a/telaio-core/src/main/java/com/paganbit/telaio/core/exception/DalInvalidFilterException.java
+++ b/telaio-core/src/main/java/com/paganbit/telaio/core/exception/DalInvalidFilterException.java
@@ -2,13 +2,15 @@ package com.paganbit.telaio.core.exception;
 
 /**
  * Exception thrown when a syntactically valid filter cannot be applied to the target entity: it
- * references a field the entity does not expose or does not persist, or uses a function that is unknown
- * or unsupported by the persistence backend.
+ * references a field the entity does not expose or does not persist, or that the current principal is not
+ * allowed to read, or uses a function that is unknown or unsupported by the persistence backend.
  *
  * <p>This is a <em>client fault</em> ({@link DalFailureKind#VALIDATION}): the request cannot be satisfied
  * as-is and must be corrected by the caller. The message may name the offending field, never a literal
  * value. A literal that does not convert to the field's type is not covered: it fails inside the
- * persistence layer, on every backend alike.</p>
+ * persistence layer, on every backend alike. The read-permission case is raised as the
+ * {@link DalFilterFieldNotReadableException} specialisation — same wire answer, distinguishable for
+ * audit.</p>
  *
  * @author Marco Pagan
  * @since 1.2.0

--- a/telaio-core/src/main/java/com/paganbit/telaio/core/json/JsonPropertyPathResolver.java
+++ b/telaio-core/src/main/java/com/paganbit/telaio/core/json/JsonPropertyPathResolver.java
@@ -85,8 +85,9 @@ public class JsonPropertyPathResolver {
      *
      * @param rootType         the type the path is rooted at
      * @param javaPath         the dot-notation path of Java property names (e.g. {@code address.zipCode})
-     * @param forSerialization {@code true} to use the serialization view (output), {@code false} for the
-     *                         deserialization view (input)
+     * @param forSerialization {@code true} to use the serialization view (output) — a property Jackson never
+     *                         writes (e.g. {@code @JsonProperty(access = WRITE_ONLY)}) does not resolve in
+     *                         it; {@code false} for the deserialization view (input)
      * @return the translated JSON-name path, or {@code null} if any segment cannot be resolved
      */
     public @Nullable String toJsonPath(Class<?> rootType, String javaPath, boolean forSerialization) {
@@ -147,7 +148,7 @@ public class JsonPropertyPathResolver {
         for (String part : jsonPath.split("\\.")) {
             if (checking) {
                 JavaType element = unwrapElements(currentType);
-                if (REFERENCE_KEY_SEGMENTS.contains(part) || isOpaque(element)) {
+                if (isReferenceKeySegment(part) || isOpaque(element)) {
                     // Dynamic keys or a reference accessor: this and every remaining segment pass through.
                     checking = false;
                 } else if (isLeaf(element)) {
@@ -206,9 +207,14 @@ public class JsonPropertyPathResolver {
     }
 
     private Map<String, PropertyMeta> introspectJsonNames(Class<?> beanClass, boolean forSerialization) {
-        // Forward: Java internal name -> JSON name.
+        // Forward: Java internal name -> JSON name. Only properties Jackson would actually write (getter or
+        // field left after access filtering) belong to the serialization view: a WRITE_ONLY property is
+        // still listed by the introspector but never appears in the output.
         Map<String, PropertyMeta> names = new HashMap<>();
         for (BeanPropertyDefinition property : introspect(beanClass, forSerialization)) {
+            if (forSerialization && !property.couldSerialize()) {
+                continue;
+            }
             names.put(property.getInternalName(), new PropertyMeta(property.getName(), property.getPrimaryType()));
         }
         return names;
@@ -282,11 +288,33 @@ public class JsonPropertyPathResolver {
         return current.getRawClass();
     }
 
+    // ------------------------------------------------------------------------
+    // Path-walking rules, shared with every component that walks a field path segment by segment
+    // (the strict filter rewrite, the RBAC filter-field checks) so that they cannot drift apart.
+    // ------------------------------------------------------------------------
+
+    /**
+     * Whether {@code segment} is a reference accessor a backend may append to a property path — the keys
+     * of a stored document reference ({@code $id}, {@code $ref}, {@code $db}). Such a segment, and every
+     * segment after it, is never checked against the bean.
+     *
+     * @param segment one dot-separated segment of a field path
+     * @return {@code true} for a reference accessor segment
+     * @since 1.2.0
+     */
+    public static boolean isReferenceKeySegment(String segment) {
+        return REFERENCE_KEY_SEGMENTS.contains(segment);
+    }
+
     /**
      * Unwraps collections and arrays (not maps) to their element type, so a path through a
      * {@code List<Contact>} resolves against {@code Contact}.
+     *
+     * @param type the declared type of the current property
+     * @return the element type, or {@code type} itself when it is not a collection or array
+     * @since 1.2.0
      */
-    private static JavaType unwrapElements(JavaType type) {
+    public static JavaType unwrapElements(JavaType type) {
         JavaType current = type;
         while (current.isCollectionLikeType() || current.isArrayType()) {
             current = current.getContentType();
@@ -297,8 +325,12 @@ public class JsonPropertyPathResolver {
     /**
      * Whether the segments applied to {@code element} cannot be checked against declared properties: maps
      * (dynamic keys), {@code Object} (unknown shape) and raw JSON trees.
+     *
+     * @param element the (element-unwrapped) type a segment is applied to
+     * @return {@code true} when the type has no introspectable properties
+     * @since 1.2.0
      */
-    private static boolean isOpaque(JavaType element) {
+    public static boolean isOpaque(JavaType element) {
         Class<?> raw = element.getRawClass();
         return element.isMapLikeType() || Object.class.equals(raw) || JsonNode.class.isAssignableFrom(raw);
     }
@@ -306,8 +338,12 @@ public class JsonPropertyPathResolver {
     /**
      * Whether {@code element} is a scalar (primitive, wrapper, string, number, temporal, enum, ...) that
      * has no addressable sub-properties, even though reflection would expose getters on it.
+     *
+     * @param element the (element-unwrapped) type a segment is applied to
+     * @return {@code true} for a scalar type
+     * @since 1.2.0
      */
-    private static boolean isLeaf(JavaType element) {
+    public static boolean isLeaf(JavaType element) {
         return SIMPLE_TYPES.test(element.getRawClass());
     }
 

--- a/telaio-core/src/test/java/com/paganbit/telaio/core/exception/DalFilterFieldNotReadableExceptionTest.java
+++ b/telaio-core/src/test/java/com/paganbit/telaio/core/exception/DalFilterFieldNotReadableExceptionTest.java
@@ -1,0 +1,26 @@
+package com.paganbit.telaio.core.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DalFilterFieldNotReadableExceptionTest {
+
+    @Test
+    void constructor_shouldNameThePathAsWrittenInTheFilter() {
+        DalFilterFieldNotReadableException exception = new DalFilterFieldNotReadableException("cost_price");
+
+        assertEquals("Filter field 'cost_price' is not readable by the current principal", exception.getMessage());
+        assertNull(exception.getCause());
+    }
+
+    @Test
+    void isAnInvalidFilterException_soTheWireAnswerStaysTheGenericClientFault() {
+        // The specialization exists for in-process consumers (audit classifies it as DENIED); on the wire
+        // it must stay indistinguishable from an unknown field: same handler, same VALIDATION kind.
+        DalFilterFieldNotReadableException exception = new DalFilterFieldNotReadableException("salary");
+
+        assertInstanceOf(DalInvalidFilterException.class, exception);
+        assertEquals(DalFailureKind.VALIDATION, DalFailureKind.of(exception));
+    }
+}

--- a/telaio-security/src/main/java/com/paganbit/telaio/security/adapter/DalRbacAdapter.java
+++ b/telaio-security/src/main/java/com/paganbit/telaio/security/adapter/DalRbacAdapter.java
@@ -13,9 +13,11 @@ import java.util.Map;
  * being performed. Telaio exposes the entity directly (there is no DTO layer), so {@code T} is the
  * entity type.</p>
  *
- * <p>Both methods are keyed by {@link DalOperationType} so a single implementation can differentiate
- * its behavior per operation (e.g., apply a stricter mask on update than on create) without widening
- * the contract. The default implementations are pass-through, so an implementor only overrides the
+ * <p>Both filtering methods are keyed by {@link DalOperationType} so a single implementation can
+ * differentiate its behavior per operation.
+ * A third hook, {@link #canFilterOn}, closes the read side: a property hidden from
+ * the response must not be usable as a filter criterion either, or its value could be inferred from the
+ * narrowed page. The default implementations are pass-through, so an implementor only overrides the
  * direction(s) it actually constrains; {@link NoopDalRbacAdapter} is exactly the no-op case.</p>
  *
  * @param <T> the exposed entity type
@@ -62,6 +64,9 @@ public interface DalRbacAdapter<T> {
      * as a generated {@code id}), even when those properties are visible to the principal. The result is
      * serialized directly to the wire, so the entity stays the boundary object (no DTO layer).</p>
      *
+     * <p>An implementation that hides properties on read must also override {@link #canFilterOn}, or the
+     * hidden fields can still be filtered on through {@code q=}.</p>
+     *
      * @param operation      the operation being performed
      * @param entity         the entity produced by the operation (can be {@code null})
      * @param authentication the current authentication context
@@ -74,5 +79,33 @@ public interface DalRbacAdapter<T> {
         Authentication authentication
     ) {
         return entity;
+    }
+
+    /**
+     * Whether the principal may reference {@code fieldPath} in the filter of a
+     * {@link DalOperationType#READ} operation.
+     *
+     * <p>Invoked once per field referenced by the caller's filter, before the read runs. Hiding a field
+     * from the response is not enough: a principal could still filter on it and work out its value from
+     * the rows that match. The rule to implement is simple — return {@code true} exactly for the fields
+     * the principal can see in the read response. A denied field is rejected with the same generic
+     * {@code 400 "Invalid filter expression"} as an unknown field, so the answer does not reveal whether
+     * the field exists.</p>
+     *
+     * <p>{@code fieldPath} is the dot-notation path <em>as written in the filter</em>: it may use the JSON
+     * wire name of a property as well as its Java name — both are accepted by the backends — so
+     * implementations must resolve it against the entity rather than compare strings.</p>
+     *
+     * <p>The default accepts every field — a compatibility choice for adapters written before this hook
+     * existed. An adapter that constrains {@link #filterOutput} must override it, or the fields it hides
+     * can still be filtered on.</p>
+     *
+     * @param fieldPath      the field path referenced by the filter, as written by the caller
+     * @param authentication the current authentication context
+     * @return {@code true} to accept the reference, {@code false} to reject the whole filter
+     * @since 1.2.0
+     */
+    default boolean canFilterOn(String fieldPath, Authentication authentication) {
+        return true;
     }
 }

--- a/telaio-security/src/main/java/com/paganbit/telaio/security/adapter/JsonViewDalRbacAdapter.java
+++ b/telaio-security/src/main/java/com/paganbit/telaio/security/adapter/JsonViewDalRbacAdapter.java
@@ -2,6 +2,7 @@ package com.paganbit.telaio.security.adapter;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.paganbit.telaio.core.adapter.DalOperationType;
+import com.paganbit.telaio.core.json.JsonPropertyPathResolver;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,7 +11,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.util.CollectionUtils;
 import tools.jackson.databind.*;
 import tools.jackson.databind.introspect.AnnotatedClass;
-import tools.jackson.databind.introspect.AnnotatedMember;
 import tools.jackson.databind.introspect.BeanPropertyDefinition;
 import tools.jackson.databind.introspect.ClassIntrospector;
 import tools.jackson.databind.json.JsonMapper;
@@ -30,7 +30,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * implements {@link #resolveView(DalOperationType, Authentication)} to pick the view for the current
  * principal and operation. Output is filtered by serializing through the view; input is filtered by
  * dropping payload keys whose property is not visible in the view, preserving the sparseness required
- * by partial (PATCH) updates.</p>
+ * by partial (PATCH) updates; a read filter may reference only properties visible in the read view
+ * ({@link #canFilterOn}).</p>
  *
  * <p><strong>Secure by default:</strong> the adapter disables {@link MapperFeature#DEFAULT_VIEW_INCLUSION}
  * on its own mapper, so a property with <em>no</em> {@code @JsonView} is excluded from every view (it
@@ -62,6 +63,12 @@ public abstract class JsonViewDalRbacAdapter<T> implements DalRbacAdapter<T> {
     private final Class<T> exposedType = resolveExposedType();
 
     private final Map<Class<?>, Map<String, PropertyInfo>> deserializationProperties = new ConcurrentHashMap<>();
+
+    /**
+     * Serialization-view properties per bean class, keyed by JSON name and by Java internal name (a filter
+     * may use either spelling).
+     */
+    private final Map<Class<?>, Map<String, PropertyInfo>> serializationProperties = new ConcurrentHashMap<>();
 
     private ObjectMapper viewMapper = secureViewMapper(JsonMapper.builder().build());
 
@@ -166,6 +173,74 @@ public abstract class JsonViewDalRbacAdapter<T> implements DalRbacAdapter<T> {
     }
 
     // ------------------------------------------------------------------------
+    // Filter-field check (reads)
+    // ------------------------------------------------------------------------
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Every segment of the path is resolved against the serialization view of the bean it applies to
+     * (JSON wire names and Java property names are both accepted) and must carry the active read view;
+     * a property with no {@code @JsonView} is denied, like on output. The keys of a {@code Map} property
+     * are not declared properties and pass unchecked, but when the map's values are beans the segments
+     * after the key are checked against the value bean — Jackson applies the view to map values too.
+     * Checking stops — and the rest of the path is accepted — once it enters an {@code Object}/
+     * {@code JsonNode} property or a map of such values, or reaches a {@code $id}/{@code $ref}/{@code $db}
+     * reference accessor. A segment applied to a scalar, or an unknown one, is denied; so is every field
+     * when {@link #resolveView} returns {@code null}.</p>
+     */
+    @Override
+    public boolean canFilterOn(String fieldPath, Authentication auth) {
+        Class<?> view = resolveView(DalOperationType.READ, auth);
+        return view != null
+            && isPathInView(List.of(fieldPath.split("\\.")), viewMapper.constructType(exposedType), view);
+    }
+
+    /**
+     * Whether every declared property along {@code segments} carries {@code view}. Same walking rules as
+     * core's strict filter rewrite ({@code JsonPropertyPathResolver.resolveJavaPath}) — including the
+     * reference-accessor check preceding the scalar check — plus the view check on every declared
+     * property, and a descent into the value bean of a {@code Map} (the rewrite has nothing to check
+     * there; the view does).
+     */
+    private boolean isPathInView(List<String> segments, JavaType type, Class<?> view) {
+        if (segments.isEmpty()) {
+            return true;
+        }
+        String segment = segments.getFirst();
+        JavaType element = JsonPropertyPathResolver.unwrapElements(type);
+        if (JsonPropertyPathResolver.isReferenceKeySegment(segment)) {
+            return true;
+        }
+        if (element.isMapLikeType()) {
+            // This segment is a map key, not a declared property; the rest applies to the map's values.
+            return isMapContentInView(rest(segments), element, view);
+        }
+        if (JsonPropertyPathResolver.isOpaque(element)) {
+            return true;
+        }
+        if (JsonPropertyPathResolver.isLeaf(element)) {
+            return false;
+        }
+        PropertyInfo info = serializationProperties(element.getRawClass()).get(segment);
+        return info != null
+            && isInView(info.views(), view)
+            && isPathInView(rest(segments), info.type(), view);
+    }
+
+    private boolean isMapContentInView(List<String> segments, JavaType map, Class<?> view) {
+        JavaType value = JsonPropertyPathResolver.unwrapElements(map.getContentType());
+        if (JsonPropertyPathResolver.isOpaque(value) || JsonPropertyPathResolver.isLeaf(value)) {
+            return true; // nothing introspectable below the keys
+        }
+        return isPathInView(segments, value, view);
+    }
+
+    private static List<String> rest(List<String> segments) {
+        return segments.subList(1, segments.size());
+    }
+
+    // ------------------------------------------------------------------------
     // View introspection
     // ------------------------------------------------------------------------
 
@@ -185,6 +260,10 @@ public abstract class JsonViewDalRbacAdapter<T> implements DalRbacAdapter<T> {
         return deserializationProperties.computeIfAbsent(beanClass, this::introspectDeserialization);
     }
 
+    private Map<String, PropertyInfo> serializationProperties(Class<?> beanClass) {
+        return serializationProperties.computeIfAbsent(beanClass, this::introspectSerialization);
+    }
+
     private Map<String, PropertyInfo> introspectDeserialization(Class<?> beanClass) {
         DeserializationConfig config = viewMapper.deserializationConfig();
         ClassIntrospector introspector = config.classIntrospectorInstance().forOperation(config);
@@ -198,20 +277,37 @@ public abstract class JsonViewDalRbacAdapter<T> implements DalRbacAdapter<T> {
         return properties;
     }
 
-    private Class<?>[] viewsOf(BeanPropertyDefinition property) {
-        AnnotatedMember[] members = {
-            property.getMutator(), property.getField(), property.getPrimaryMember(), property.getGetter()
-        };
-        for (AnnotatedMember member : members) {
-            if (member == null) {
-                continue;
-            }
-            JsonView jsonView = member.getAnnotation(JsonView.class);
-            if (jsonView != null) {
-                return jsonView.value();
-            }
+    private Map<String, PropertyInfo> introspectSerialization(Class<?> beanClass) {
+        SerializationConfig config = viewMapper.serializationConfig();
+        ClassIntrospector introspector = config.classIntrospectorInstance().forOperation(config);
+        JavaType type = viewMapper.constructType(beanClass);
+        AnnotatedClass annotatedClass = introspector.introspectClassAnnotations(type);
+        BeanDescription description = introspector.introspectForSerialization(type, annotatedClass);
+        // Only properties Jackson would actually write: a WRITE_ONLY property is listed by the introspector
+        // but never serialized, so it must not be filterable either.
+        List<BeanPropertyDefinition> serialized = description.findProperties().stream()
+            .filter(BeanPropertyDefinition::couldSerialize)
+            .toList();
+        Map<String, PropertyInfo> properties = new HashMap<>();
+        // Wire names first so that a JSON name always wins over a Java name spelled the same way.
+        for (BeanPropertyDefinition property : serialized) {
+            properties.put(property.getName(), new PropertyInfo(property.getPrimaryType(), viewsOf(property)));
         }
-        return NO_VIEWS;
+        for (BeanPropertyDefinition property : serialized) {
+            properties.putIfAbsent(
+                property.getInternalName(), new PropertyInfo(property.getPrimaryType(), viewsOf(property)));
+        }
+        return properties;
+    }
+
+    /**
+     * The views a property is tagged with, resolved by Jackson for the operation the property was
+     * introspected for — getter-first for serialization, setter-first for deserialization — so that a
+     * property annotated per accessor is classified exactly as Jackson will serialize or bind it.
+     */
+    private static Class<?>[] viewsOf(BeanPropertyDefinition property) {
+        Class<?>[] views = property.findViews();
+        return views != null ? views : NO_VIEWS;
     }
 
     private Class<?> rawContentClass(JavaType type) {

--- a/telaio-security/src/main/java/com/paganbit/telaio/security/adapter/PropertyBasedDalRbacAdapter.java
+++ b/telaio-security/src/main/java/com/paganbit/telaio/security/adapter/PropertyBasedDalRbacAdapter.java
@@ -297,6 +297,37 @@ public abstract class PropertyBasedDalRbacAdapter<T> implements DalRbacAdapter<T
     }
 
     // ------------------------------------------------------------------------
+    // Filter-field check (reads)
+    // ------------------------------------------------------------------------
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The path is resolved to Java property names (JSON wire names and Java names are both accepted,
+     * as the backends do) and checked with the very rules {@link #pruneOutput} applies to the response:
+     * the property must be serialized (a write-only or {@code @JsonIgnore}d property never appears in the
+     * response, so it is not filterable even when listed in the readable map) and granted for read —
+     * exactly, or through a granted descendant (the field is then present as a pruned object). A bare
+     * grant on a parent does <em>not</em> extend to its children — they are pruned from the response, so
+     * they cannot be filtered on either. The keys below a {@code Map} property and the
+     * {@code $id}/{@code $ref}/{@code $db} accessors of a stored reference are not serialized properties
+     * and are never filterable through this adapter. An unresolvable path is denied.</p>
+     */
+    @Override
+    public boolean canFilterOn(String fieldPath, Authentication auth) {
+        JsonPropertyPathResolver.JavaPathResolution resolution = pathResolver.resolveJavaPath(exposedType, fieldPath);
+        if (!resolution.resolved()) {
+            return false;
+        }
+        String javaPath = resolution.javaPath();
+        if (pathResolver.toJsonPath(exposedType, javaPath, true) == null) {
+            return false; // not part of the serialized form: the response never shows it
+        }
+        Set<String> allowedJavaFields = resolveEffectiveFields(auth, readReadable.get());
+        return allowedJavaFields.contains(javaPath) || hasDescendant(allowedJavaFields, javaPath);
+    }
+
+    // ------------------------------------------------------------------------
     // Java-property -> JSON name translation
     // ------------------------------------------------------------------------
 

--- a/telaio-security/src/main/java/com/paganbit/telaio/security/interceptor/DalSecurityInterceptor.java
+++ b/telaio-security/src/main/java/com/paganbit/telaio/security/interceptor/DalSecurityInterceptor.java
@@ -3,13 +3,18 @@ package com.paganbit.telaio.security.interceptor;
 import com.paganbit.telaio.core.adapter.DalOperation;
 import com.paganbit.telaio.core.adapter.DalOperationAdapter;
 import com.paganbit.telaio.core.adapter.DalOperationType;
+import com.paganbit.telaio.core.exception.DalFilterFieldNotReadableException;
+import com.paganbit.telaio.core.filter.FilterNodes;
 import com.paganbit.telaio.security.DalSecurityContextHelper;
 import com.paganbit.telaio.security.adapter.DalAuthAdapter;
 import com.paganbit.telaio.security.adapter.DalRbacAdapter;
 import com.paganbit.telaio.security.exception.DalAccessDeniedException;
 import com.paganbit.telaio.security.exception.DalAccessDeniedMessageResolver;
+import com.turkraft.springfilter.parser.node.FieldNode;
+import com.turkraft.springfilter.parser.node.FilterNode;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.Authentication;
 
@@ -20,10 +25,18 @@ import java.util.Optional;
 /**
  * Applies a DAL's authorization and RBAC policy to its operation adapter.
  *
- * <p>Each operation is identified via its {@link DalOperation} annotation — authorization is
- * checked through the {@link DalAuthAdapter} and input/output are filtered through the
- * {@link DalRbacAdapter}. Methods without a {@link DalOperation} annotation are passed through
- * unchanged. The {@link Authentication} is read from the current Spring Security context.</p>
+ * <p>Each operation is identified via its {@link DalOperation} annotation and goes through, in order:</p>
+ * <ol>
+ *   <li>authorization, via the {@link DalAuthAdapter};</li>
+ *   <li>for reads with a filter, a {@link DalRbacAdapter#canFilterOn} check on every referenced field —
+ *       a field the principal may not read rejects the request with a
+ *       {@link DalFilterFieldNotReadableException} (on the wire the same client fault as an unknown
+ *       field; for audit a denied attempt);</li>
+ *   <li>input/output filtering, via the {@link DalRbacAdapter}.</li>
+ * </ol>
+ *
+ * <p>Methods without a {@link DalOperation} annotation are passed through unchanged. The
+ * {@link Authentication} is read from the current Spring Security context.</p>
  *
  * @author Marco Pagan
  * @since 1.0.0
@@ -71,6 +84,7 @@ public class DalSecurityInterceptor implements MethodInterceptor {
             }
             case READ -> {
                 require(authAdapter.authorizeRead(auth), messageResolver.forRead(dalName));
+                requireReadableFilterFields((FilterNode) args[0], auth);
                 Page page = Objects.requireNonNull((Page) invocation.proceed());
                 yield page.map(dto -> rbacAdapter.filterOutput(DalOperationType.READ, dto, auth));
             }
@@ -97,6 +111,22 @@ public class DalSecurityInterceptor implements MethodInterceptor {
     private static void require(boolean authorized, String message) {
         if (!authorized) {
             throw new DalAccessDeniedException(message);
+        }
+    }
+
+    /**
+     * Rejects a read filter that references a field the principal may not read — checked after the
+     * operation-level authorization (a denied read stays a {@code 403}) and before the read runs, so no
+     * query is ever executed on a hidden property.
+     */
+    private void requireReadableFilterFields(@Nullable FilterNode filter, Authentication auth) {
+        if (filter == null) {
+            return;
+        }
+        for (FieldNode field : FilterNodes.fieldNodes(filter)) {
+            if (!rbacAdapter.canFilterOn(field.getName(), auth)) {
+                throw new DalFilterFieldNotReadableException(field.getName());
+            }
         }
     }
 }

--- a/telaio-security/src/test/java/com/paganbit/telaio/security/adapter/JsonViewDalRbacAdapterTest.java
+++ b/telaio-security/src/test/java/com/paganbit/telaio/security/adapter/JsonViewDalRbacAdapterTest.java
@@ -21,6 +21,7 @@ import tools.jackson.databind.json.JsonMapper;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doReturn;
@@ -302,6 +303,128 @@ class JsonViewDalRbacAdapterTest {
         assertThrows(IllegalStateException.class, RawJsonViewAdapter::new);
     }
 
+    // ------------------------------------------------------------------------
+    // Filter-field check (reads)
+    // ------------------------------------------------------------------------
+
+    @Test
+    void filter_publicRole_mayReferenceOnlyPublicProperties() {
+        doReturn(List.of(Roles.PUBLIC)).when(auth).getAuthorities();
+
+        assertTrue(adapter.canFilterOn("title", auth));
+        assertFalse(adapter.canFilterOn("secret", auth), "Internal-only: filtering is denied");
+        assertFalse(adapter.canFilterOn("hidden", auth), "no @JsonView: visible in no view, like on output");
+    }
+
+    @Test
+    void filter_internalRole_inheritsPublicAndAddsInternal() {
+        doReturn(List.of(Roles.INTERNAL)).when(auth).getAuthorities();
+
+        assertTrue(adapter.canFilterOn("title", auth));
+        assertTrue(adapter.canFilterOn("secret", auth));
+        assertFalse(adapter.canFilterOn("hidden", auth));
+    }
+
+    @Test
+    void filter_withoutView_deniesEveryField() {
+        doReturn(List.of()).when(auth).getAuthorities();
+
+        assertFalse(adapter.canFilterOn("title", auth));
+    }
+
+    @Test
+    void filter_nestedPath_isCheckedAgainstTheElementBean() {
+        NestedAdapter nested = new NestedAdapter();
+        nested.setObjectMapper(JsonMapper.builder().build());
+        doReturn(List.of(Roles.PUBLIC)).when(auth).getAuthorities();
+
+        assertTrue(nested.canFilterOn("child.visible", auth));
+        assertFalse(nested.canFilterOn("child.secret", auth));
+        assertTrue(nested.canFilterOn("members.visible", auth), "collections resolve against their element type");
+        assertFalse(nested.canFilterOn("members.hidden", auth));
+        assertTrue(nested.canFilterOn("tags", auth));
+        assertFalse(nested.canFilterOn("tags.length", auth), "a segment applied to a scalar never resolves");
+        assertFalse(nested.canFilterOn("child.nope", auth));
+        assertFalse(nested.canFilterOn("nope", auth));
+    }
+
+    @Test
+    void filter_renamedProperty_acceptsWireAndJavaNameAlike() {
+        // A filter may spell a property by its @JsonProperty wire name or by its Java name (the backends
+        // accept both), so the view must be enforced under both spellings — or the Java name would bypass it.
+        AliasedAdapter aliased = new AliasedAdapter();
+        aliased.setObjectMapper(JsonMapper.builder().build());
+        doReturn(List.of(Roles.PUBLIC)).when(auth).getAuthorities();
+
+        assertTrue(aliased.canFilterOn("full_name", auth));
+        assertTrue(aliased.canFilterOn("name", auth));
+        assertFalse(aliased.canFilterOn("secret_code", auth));
+        assertFalse(aliased.canFilterOn("secret", auth));
+    }
+
+    @Test
+    void filter_writeOnlyPropertyInTheView_isDeniedLikeOnOutput() {
+        // In the view, yet never serialized: the response does not carry it, so neither may a filter.
+        AliasedAdapter aliased = new AliasedAdapter();
+        aliased.setObjectMapper(JsonMapper.builder().build());
+        doReturn(List.of(Roles.PUBLIC)).when(auth).getAuthorities();
+        AliasedDoc doc = new AliasedDoc();
+        doc.setToken("t");
+
+        JsonNode output = (JsonNode) aliased.filterOutput(DalOperationType.READ, doc, auth);
+
+        assertFalse(output.has("token"));
+        assertFalse(aliased.canFilterOn("token", auth));
+    }
+
+    @Test
+    void filter_belowAMapProperty_acceptsAnyKeyWhenTheMapIsInView() {
+        BagAdapter bag = new BagAdapter();
+        bag.setObjectMapper(JsonMapper.builder().build());
+        doReturn(List.of(Roles.PUBLIC)).when(auth).getAuthorities();
+
+        assertTrue(bag.canFilterOn("attributes.any.key", auth), "map keys are not declared properties");
+        assertFalse(bag.canFilterOn("hiddenAttributes.key", auth), "the map itself is out of view");
+    }
+
+    @Test
+    void filter_perAccessorViews_followTheGetterLikeSerialization() {
+        // ssn: writable by Public (setter), visible to Internal only (getter) — the filter must follow the
+        // getter, exactly like the response does, or Public could bisect ssn through `ssn ~ '123*'`.
+        // note: the reverse split — readable by Public (getter), writable by Internal (setter).
+        AccessorAdapter accessor = new AccessorAdapter();
+        accessor.setObjectMapper(JsonMapper.builder().build());
+        doReturn(List.of(Roles.PUBLIC)).when(auth).getAuthorities();
+        AccessorDoc doc = new AccessorDoc();
+        doc.setSsn("123-45-6789");
+        doc.setNote("n");
+
+        JsonNode output = (JsonNode) accessor.filterOutput(DalOperationType.READ, doc, auth);
+        Map<String, Object> input = accessor.filterInput(
+            DalOperationType.UPDATE, new HashMap<>(Map.of("ssn", "x", "note", "y")), auth);
+
+        assertFalse(output.has("ssn"), "the response follows the getter view (Internal)");
+        assertFalse(accessor.canFilterOn("ssn", auth), "so must the filter");
+        assertTrue(output.has("note"));
+        assertTrue(accessor.canFilterOn("note", auth));
+        assertEquals(Set.of("ssn"), input.keySet(), "input follows the setter view: ssn writable, note not");
+    }
+
+    @Test
+    void filter_belowAMapOfBeans_checksTheValueBeanAgainstTheView() {
+        // Jackson applies the view to map values too: a hidden property of the value bean is pruned from
+        // the response, so it must not be reachable through `members.<key>.secret` either.
+        BagAdapter bag = new BagAdapter();
+        bag.setObjectMapper(JsonMapper.builder().build());
+        doReturn(List.of(Roles.PUBLIC)).when(auth).getAuthorities();
+
+        assertTrue(bag.canFilterOn("members.alice.visible", auth));
+        assertFalse(bag.canFilterOn("members.alice.secret", auth));
+        assertFalse(bag.canFilterOn("members.alice.hidden", auth));
+        assertFalse(bag.canFilterOn("members.alice.nope", auth));
+        assertTrue(bag.canFilterOn("members.alice", auth), "the key alone addresses the visible value");
+    }
+
     private static Map<String, Object> member(String visible, String secret, String hidden) {
         Map<String, Object> map = new HashMap<>();
         map.put("visible", visible);
@@ -361,6 +484,27 @@ class JsonViewDalRbacAdapterTest {
         }
     }
 
+    private static class AliasedAdapter extends JsonViewDalRbacAdapter<AliasedDoc> {
+        @Override
+        protected Class<?> resolveView(DalOperationType operation, Authentication authentication) {
+            return authentication.getAuthorities().contains(Roles.PUBLIC) ? Views.Public.class : null;
+        }
+    }
+
+    private static class AccessorAdapter extends JsonViewDalRbacAdapter<AccessorDoc> {
+        @Override
+        protected Class<?> resolveView(DalOperationType operation, Authentication authentication) {
+            return authentication.getAuthorities().contains(Roles.PUBLIC) ? Views.Public.class : null;
+        }
+    }
+
+    private static class BagAdapter extends JsonViewDalRbacAdapter<Bag> {
+        @Override
+        protected Class<?> resolveView(DalOperationType operation, Authentication authentication) {
+            return authentication.getAuthorities().contains(Roles.PUBLIC) ? Views.Public.class : null;
+        }
+    }
+
     @SuppressWarnings("rawtypes")
     private static class RawJsonViewAdapter extends JsonViewDalRbacAdapter {
         @Override
@@ -416,6 +560,61 @@ class JsonViewDalRbacAdapterTest {
         @JsonView(Views.Internal.class)
         private String secret;
         private String hidden;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    static class AliasedDoc {
+        @JsonView(Views.Public.class)
+        @JsonProperty("full_name")
+        private String name;
+        @JsonView(Views.Internal.class)
+        @JsonProperty("secret_code")
+        private String secret;
+        @JsonView(Views.Public.class)
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+        private String token;
+    }
+
+    /**
+     * Views declared per accessor: {@code ssn} is Public on the setter and Internal on the getter,
+     * {@code note} the other way round.
+     */
+    static class AccessorDoc {
+        private String ssn;
+        private String note;
+
+        @JsonView(Views.Internal.class)
+        public String getSsn() {
+            return ssn;
+        }
+
+        @JsonView(Views.Public.class)
+        public void setSsn(String ssn) {
+            this.ssn = ssn;
+        }
+
+        @JsonView(Views.Public.class)
+        public String getNote() {
+            return note;
+        }
+
+        @JsonView(Views.Internal.class)
+        public void setNote(String note) {
+            this.note = note;
+        }
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    static class Bag {
+        @JsonView(Views.Public.class)
+        private Map<String, Object> attributes;
+        private Map<String, Object> hiddenAttributes;
+        @JsonView(Views.Public.class)
+        private Map<String, Member> members;
     }
 
     static class ExplodingDoc {

--- a/telaio-security/src/test/java/com/paganbit/telaio/security/adapter/NoopDalRbacAdapterTest.java
+++ b/telaio-security/src/test/java/com/paganbit/telaio/security/adapter/NoopDalRbacAdapterTest.java
@@ -11,8 +11,7 @@ import org.springframework.security.core.Authentication;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 class NoopDalRbacAdapterTest {
@@ -65,6 +64,12 @@ class NoopDalRbacAdapterTest {
     @Test
     void shouldNotFilterUpdateOutput() {
         assertSame(testDto, adapter.filterOutput(DalOperationType.UPDATE, testDto, mockAuthentication));
+    }
+
+    @Test
+    void shouldAllowFilteringOnAnyField() {
+        assertTrue(adapter.canFilterOn("name", mockAuthentication));
+        assertTrue(adapter.canFilterOn("nested.secret", mockAuthentication));
     }
 
     record TestDto(String name) {

--- a/telaio-security/src/test/java/com/paganbit/telaio/security/adapter/PropertyBasedDalRbacAdapterTest.java
+++ b/telaio-security/src/test/java/com/paganbit/telaio/security/adapter/PropertyBasedDalRbacAdapterTest.java
@@ -669,6 +669,103 @@ class PropertyBasedDalRbacAdapterTest {
     }
 
     // ------------------------------------------------------------------------
+    // Filter-field check (reads)
+    // ------------------------------------------------------------------------
+
+    @Test
+    void filter_readableFields_areAllowed() {
+        doReturn(List.of(UserAuthority.USER)).when(mockAuthentication).getAuthorities();
+
+        assertTrue(defaultAdapter.canFilterOn("name", mockAuthentication));
+        assertTrue(defaultAdapter.canFilterOn("address.city", mockAuthentication));
+    }
+
+    @Test
+    void filter_hiddenFields_areDenied() {
+        // USER cannot read 'role' (ADMIN-only) nor 'address.zipCode' (MANAGER/ADMIN): neither may be used
+        // as a filter criterion, or its value could be bisected from the narrowed page.
+        doReturn(List.of(UserAuthority.USER)).when(mockAuthentication).getAuthorities();
+
+        assertFalse(defaultAdapter.canFilterOn("role", mockAuthentication));
+        assertFalse(defaultAdapter.canFilterOn("address.zipCode", mockAuthentication));
+    }
+
+    @Test
+    void filter_usesTheUnionOfTheRoles() {
+        doReturn(List.of(UserAuthority.USER, UserAuthority.ADMIN)).when(mockAuthentication).getAuthorities();
+
+        assertTrue(defaultAdapter.canFilterOn("role", mockAuthentication));
+    }
+
+    @Test
+    void filter_renamedField_isCheckedUnderBothSpellings() {
+        // The grant is authored with the Java name; the filter may use the wire name or the Java name —
+        // both resolve to the same property, and the hidden one is denied under both spellings too.
+        RenameAdapter adapter = new RenameAdapter();
+        adapter.setObjectMapper(objectMapper);
+        doReturn(List.of(UserAuthority.USER)).when(mockAuthentication).getAuthorities();
+
+        assertTrue(adapter.canFilterOn("full_name", mockAuthentication));
+        assertTrue(adapter.canFilterOn("name", mockAuthentication));
+        assertFalse(adapter.canFilterOn("secret", mockAuthentication));
+    }
+
+    @Test
+    void filter_parentWithGrantedDescendant_isAllowedButUngrantedSiblingIsNot() {
+        // Mirrors output pruning: 'address' appears in the response (pruned to 'street'), so it may be
+        // referenced (e.g. `address is null`); 'address.city' is pruned away, so it may not.
+        DescendantReadableAdapter adapter = new DescendantReadableAdapter();
+        adapter.setObjectMapper(objectMapper);
+        doReturn(List.of(UserAuthority.USER)).when(mockAuthentication).getAuthorities();
+
+        assertTrue(adapter.canFilterOn("address", mockAuthentication));
+        assertTrue(adapter.canFilterOn("address.street", mockAuthentication));
+        assertFalse(adapter.canFilterOn("address.city", mockAuthentication));
+    }
+
+    @Test
+    void filter_childOfBareParentGrant_isDeniedLikeOnOutput() {
+        // A bare 'address' grant prunes every child from the response
+        // (output_parentGrantWithoutChildren_removesEmptiedNestedObject) — so the children are not
+        // filterable either; the parent itself still is.
+        ParentOnlyReadableAdapter adapter = new ParentOnlyReadableAdapter();
+        adapter.setObjectMapper(objectMapper);
+        doReturn(List.of(UserAuthority.USER)).when(mockAuthentication).getAuthorities();
+
+        assertTrue(adapter.canFilterOn("address", mockAuthentication));
+        assertFalse(adapter.canFilterOn("address.zipCode", mockAuthentication));
+    }
+
+    @Test
+    void filter_grantOnAPropertyTheResponseNeverShows_isDenied() {
+        // 'password' is write-only: listed as readable by mistake, it is still never serialized, so the
+        // filter must not open a channel the response does not have.
+        CredentialsAdapter adapter = new CredentialsAdapter();
+        adapter.setObjectMapper(objectMapper);
+        doReturn(List.of(UserAuthority.USER)).when(mockAuthentication).getAuthorities();
+
+        JsonNode output = (JsonNode) adapter.filterOutput(
+            DalOperationType.READ, new Credentials("bob", "s3cret"), mockAuthentication);
+
+        assertFalse(output.has("password"));
+        assertFalse(adapter.canFilterOn("password", mockAuthentication));
+        assertTrue(adapter.canFilterOn("name", mockAuthentication));
+    }
+
+    @Test
+    void filter_unknownField_isDenied() {
+        // Denied before the roles are even consulted: an unresolvable path is never readable.
+        assertFalse(defaultAdapter.canFilterOn("nope", mockAuthentication));
+        assertFalse(defaultAdapter.canFilterOn("address.nope", mockAuthentication));
+        assertFalse(defaultAdapter.canFilterOn("name.length", mockAuthentication), "segment on a scalar");
+    }
+
+    @Test
+    void filter_withoutAuthentication_isDenied() {
+        assertFalse(defaultAdapter.canFilterOn("name", null));
+    }
+
+    // ------------------------------------------------------------------------
     // Exposed-type resolution
     // ------------------------------------------------------------------------
 
@@ -843,6 +940,18 @@ class PropertyBasedDalRbacAdapterTest {
         @Override
         protected Map<GrantedAuthority, Set<String>> writableFieldsByRole() {
             return Map.of(UserAuthority.USER, Set.of("name"));
+        }
+    }
+
+    private static class CredentialsAdapter extends PropertyBasedDalRbacAdapter<Credentials> {
+        @Override
+        protected Map<GrantedAuthority, Set<String>> readableFieldsByRole() {
+            return Map.of(UserAuthority.USER, Set.of("name", "password"));
+        }
+
+        @Override
+        protected Map<GrantedAuthority, Set<String>> writableFieldsByRole() {
+            return Map.of(UserAuthority.USER, Set.of("name", "password"));
         }
     }
 
@@ -1072,6 +1181,16 @@ class PropertyBasedDalRbacAdapterTest {
         @JsonProperty("full_name")
         private String name;
         private String secret;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    static class Credentials {
+        private String name;
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+        private String password;
     }
 
     @Getter

--- a/telaio-security/src/test/java/com/paganbit/telaio/security/interceptor/DalSecurityInterceptorTest.java
+++ b/telaio-security/src/test/java/com/paganbit/telaio/security/interceptor/DalSecurityInterceptorTest.java
@@ -2,10 +2,16 @@ package com.paganbit.telaio.security.interceptor;
 
 import com.paganbit.telaio.core.adapter.DalOperationAdapter;
 import com.paganbit.telaio.core.adapter.DalOperationType;
+import com.paganbit.telaio.core.exception.DalInvalidFilterException;
 import com.paganbit.telaio.security.adapter.DalAuthAdapter;
 import com.paganbit.telaio.security.adapter.DalRbacAdapter;
 import com.paganbit.telaio.security.exception.DalAccessDeniedException;
 import com.paganbit.telaio.security.exception.DefaultDalAccessDeniedMessageResolver;
+import com.turkraft.springfilter.definition.FilterInfixOperator;
+import com.turkraft.springfilter.parser.node.FieldNode;
+import com.turkraft.springfilter.parser.node.FilterNode;
+import com.turkraft.springfilter.parser.node.InfixOperationNode;
+import com.turkraft.springfilter.parser.node.InputNode;
 import org.aopalliance.intercept.MethodInvocation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,7 +21,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -32,6 +40,8 @@ class DalSecurityInterceptorTest {
     private DalRbacAdapter<Object> rbacAdapter;
     @Mock
     private MethodInvocation invocation;
+    @Mock
+    private FilterInfixOperator infix;
 
     private DalSecurityInterceptor interceptor;
 
@@ -86,6 +96,73 @@ class DalSecurityInterceptorTest {
 
         assertNotNull(result);
         assertEquals(List.of("a!", "b!"), result.getContent());
+    }
+
+    @Test
+    void read_withoutFilter_shouldNotConsultTheAdapterForFilterFields() throws Throwable {
+        when(invocation.getMethod()).thenReturn(readMethod());
+        when(invocation.getArguments()).thenReturn(new Object[]{null, null});
+        when(authAdapter.authorizeRead(any())).thenReturn(true);
+        when(invocation.proceed()).thenReturn(new PageImpl<>(List.of()));
+
+        interceptor.invoke(invocation);
+
+        verify(rbacAdapter, never()).canFilterOn(any(), any());
+    }
+
+    @Test
+    void read_whenFilterReferencesHiddenField_shouldRejectBeforeProceeding() throws Throwable {
+        // The security property: the adapter denies the field, so the read never runs — otherwise the
+        // narrowed page would leak the hidden value (bisection through `cost_price > 100`).
+        FilterNode filter = comparison("cost_price");
+        when(invocation.getMethod()).thenReturn(readMethod());
+        when(invocation.getArguments()).thenReturn(new Object[]{filter, null});
+        when(authAdapter.authorizeRead(any())).thenReturn(true);
+        when(rbacAdapter.canFilterOn(eq("cost_price"), any())).thenReturn(false);
+
+        assertThrows(DalInvalidFilterException.class, () -> interceptor.invoke(invocation));
+
+        verify(invocation, never()).proceed();
+        verify(rbacAdapter, never()).filterOutput(any(), any(), any());
+        // Operation-level authorization comes first, so a denied read stays a 403, never a 400.
+        InOrder inOrder = inOrder(authAdapter, rbacAdapter);
+        inOrder.verify(authAdapter).authorizeRead(any());
+        inOrder.verify(rbacAdapter).canFilterOn(eq("cost_price"), any());
+    }
+
+    @Test
+    void read_whenEveryFilterFieldIsReadable_shouldCheckEachFieldAndProceed() throws Throwable {
+        FilterNode filter = new InfixOperationNode(comparison("name"), infix, comparison("price"));
+        Page<Object> page = new PageImpl<>(List.of("a"));
+        when(invocation.getMethod()).thenReturn(readMethod());
+        when(invocation.getArguments()).thenReturn(new Object[]{filter, null});
+        when(authAdapter.authorizeRead(any())).thenReturn(true);
+        when(rbacAdapter.canFilterOn(any(), any())).thenReturn(true);
+        when(invocation.proceed()).thenReturn(page);
+        when(rbacAdapter.filterOutput(eq(DalOperationType.READ), any(), any()))
+            .thenAnswer(inv -> inv.getArgument(1));
+
+        @SuppressWarnings("unchecked")
+        Page<Object> result = (Page<Object>) interceptor.invoke(invocation);
+
+        assertNotNull(result);
+        assertEquals(List.of("a"), result.getContent());
+        verify(rbacAdapter).canFilterOn(eq("name"), any());
+        verify(rbacAdapter).canFilterOn(eq("price"), any());
+        verify(invocation).proceed();
+    }
+
+    @Test
+    void read_whenDenied_shouldNotInspectTheFilter() throws Throwable {
+        FilterNode filter = comparison("cost_price");
+        when(invocation.getMethod()).thenReturn(readMethod());
+        when(invocation.getArguments()).thenReturn(new Object[]{filter, null});
+        when(authAdapter.authorizeRead(any())).thenReturn(false);
+
+        assertThrows(DalAccessDeniedException.class, () -> interceptor.invoke(invocation));
+
+        verify(invocation, never()).proceed();
+        verifyNoInteractions(rbacAdapter);
     }
 
     @Test
@@ -197,6 +274,17 @@ class DalSecurityInterceptorTest {
 
         assertThrows(IllegalStateException.class, () -> interceptor.invoke(invocation));
         verifyNoInteractions(authAdapter, rbacAdapter);
+    }
+
+    private static Method readMethod() throws NoSuchMethodException {
+        return DalOperationAdapter.class.getMethod("read", FilterNode.class, Pageable.class);
+    }
+
+    /**
+     * A {@code field <op> 1} comparison; the operator is a mock — only the tree shape matters here.
+     */
+    private FilterNode comparison(String field) {
+        return new InfixOperationNode(new FieldNode(field), infix, new InputNode(1));
     }
 
     /**

--- a/telaio-showcase/src/main/resources/application.properties
+++ b/telaio-showcase/src/main/resources/application.properties
@@ -1,6 +1,0 @@
-# Deliberately a .properties file next to application.yaml: the Turkraft Spring Filter `mongo` jar ships an
-# application.properties at its root that turns MongoTemplate logging to DEBUG for every consumer. Spring Boot
-# loads a single classpath:/application.properties (this one, first on the classpath) and .properties takes
-# precedence over .yaml at the same location, so the override is only effective from here.
-# TODO consider proposing a PR to the Turkraft library to remove that file.
-logging.level.org.springframework.data.mongodb.core.MongoTemplate=WARN

--- a/telaio-showcase/src/test/java/com/paganbit/telaio/showcase/it/AbstractShowcaseIT.java
+++ b/telaio-showcase/src/test/java/com/paganbit/telaio/showcase/it/AbstractShowcaseIT.java
@@ -16,6 +16,8 @@ import tools.jackson.databind.json.JsonMapper;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Base class for the showcase end-to-end integration tests. Boots the whole application on a random
  * port against a real PostgreSQL (Testcontainers) and drives it over genuine HTTP through the full
@@ -113,5 +115,17 @@ abstract class AbstractShowcaseIT {
      */
     protected String body(Map<String, ?> map) {
         return JSON.writeValueAsString(map);
+    }
+
+    // --- Assertions ---------------------------------------------------------------------------
+
+    /**
+     * Asserts the generic client fault for a well-formed {@code q=} filter the request cannot honor —
+     * unknown, non-persistent or non-readable field, unknown function — which is deliberately the same
+     * body in every case.
+     */
+    protected void assertInvalidFilter(ResponseEntity<String> response) {
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(tree(response).path("detail").asString()).isEqualTo("Invalid filter expression");
     }
 }

--- a/telaio-showcase/src/test/java/com/paganbit/telaio/showcase/it/DalApiErrorsIT.java
+++ b/telaio-showcase/src/test/java/com/paganbit/telaio/showcase/it/DalApiErrorsIT.java
@@ -80,9 +80,4 @@ class DalApiErrorsIT extends AbstractShowcaseIT {
         assertThat(matched).isPositive();
         assertThat(tree(byJavaName).path("page").path("totalElements").asLong()).isEqualTo(matched);
     }
-
-    private void assertInvalidFilter(ResponseEntity<String> response) {
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(tree(response).path("detail").asString()).isEqualTo("Invalid filter expression");
-    }
 }

--- a/telaio-showcase/src/test/java/com/paganbit/telaio/showcase/it/RbacFilterFieldIT.java
+++ b/telaio-showcase/src/test/java/com/paganbit/telaio/showcase/it/RbacFilterFieldIT.java
@@ -1,0 +1,57 @@
+package com.paganbit.telaio.showcase.it;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Cross-cutting — field-level RBAC also governs the {@code q=} filter. A principal may not filter on a
+ * property the RBAC adapter hides from them: the rows that come back would otherwise reveal its value
+ * (bisection through {@code cost_price > 100}). Covered for both built-in adapters — property maps
+ * ({@code products}: {@code cost_price}/{@code internal_sku} readable by DEVELOPER only) and
+ * {@code @JsonView} ({@code employees}: {@code salary} in the Developer view, {@code employeeEmail} from the
+ * Admin view up) — under the wire name and the Java name alike. The rejection is the same generic 400 as an
+ * unknown field, so the filter cannot be used to probe which hidden properties exist either.
+ */
+class RbacFilterFieldIT extends AbstractShowcaseIT {
+
+    @Test
+    void propertyMapAdapter_rejectsAFilterOnAHiddenField() {
+        assertInvalidFilter(list(USER, "products", "q=cost_price>100"));
+        assertInvalidFilter(list(USER, "products", "q=costPrice>100"));
+        assertInvalidFilter(list(ADMIN, "products", "q=internal_sku:'x'"));
+    }
+
+    @Test
+    void propertyMapAdapter_stillFiltersOnReadableFields() {
+        ResponseEntity<String> developer = list(DEVELOPER, "products", "q=cost_price>0");
+        ResponseEntity<String> user = list(USER, "products", "q=price>0");
+
+        assertThat(developer.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(tree(developer).path("page").path("totalElements").asLong()).isPositive();
+        assertThat(user.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(tree(user).path("page").path("totalElements").asLong()).isPositive();
+    }
+
+    @Test
+    void jsonViewAdapter_rejectsAFilterOnAFieldOutsideTheView() {
+        assertInvalidFilter(list(USER, "employees", "q=salary>1000"));
+        assertInvalidFilter(list(ADMIN, "employees", "q=salary>1000"));
+        assertInvalidFilter(list(USER, "employees", "q=employeeEmail~'*a*'"));
+        assertInvalidFilter(list(USER, "employees", "q=email~'*a*'"));
+    }
+
+    @Test
+    void jsonViewAdapter_stillFiltersOnFieldsInTheView() {
+        ResponseEntity<String> developer = list(DEVELOPER, "employees", "q=salary>0");
+        ResponseEntity<String> admin = list(ADMIN, "employees", "q=employeeEmail~'*@*'");
+        ResponseEntity<String> user = list(USER, "employees", "q=employeeName~'*a*'");
+
+        assertThat(developer.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(admin.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(user.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(tree(user).path("page").path("totalElements").asLong()).isPositive();
+    }
+}

--- a/telaio-web/src/main/java/com/paganbit/telaio/web/exception/TelaioWebExceptionHandler.java
+++ b/telaio-web/src/main/java/com/paganbit/telaio/web/exception/TelaioWebExceptionHandler.java
@@ -60,18 +60,17 @@ public class TelaioWebExceptionHandler {
 
     /**
      * Maps a well-formed {@code q} filter that cannot be applied to the target entity — an unknown or
-     * non-persistent field, or a function that is unknown or unsupported by the persistence backend — to
-     * {@code 400 Bad Request}. Raised uniformly by every backend's filter converter,
-     * so the same request fails the same way on JPA and Mongo instead of surfacing as a server error or
-     * silently matching nothing. The body carries a stable, generic detail; the field name stays in the
-     * on-demand debug log only.
+     * non-persistent field, a field the principal is not allowed to read, or a function that is unknown or
+     * unsupported by the persistence backend — to {@code 400 Bad Request}. Raised uniformly by every
+     * backend's filter converter (and, for the RBAC case, by the security interceptor before the read).
+     * The body carries a stable, generic detail; the field name stays in the on-demand debug log only.
      */
     @ExceptionHandler(DalInvalidFilterException.class)
     ProblemDetail handleInvalidFilter(DalInvalidFilterException ex) {
         // The wrapped cause names the failing conversion/function; its type is enough to tell the cases
         // apart, and its message (which may echo the rejected literal) stays out of the log.
         log.debug("Invalid filter expression rejected: {} ({})", ex.getMessage(),
-            ex.getCause() != null ? ex.getCause().getClass().getName() : "unresolved field");
+            ex.getCause() != null ? ex.getCause().getClass().getName() : "no cause");
         return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "Invalid filter expression");
     }
 


### PR DESCRIPTION
## Summary

Field-level RBAC pruned the *response* only: a principal with READ could still filter on a hidden property (`q=cost_price>100`) and work out its value from the rows that come back. Closes **roadmap item 8** (plus the item 2 residual); opens item 10 (`sort=` counterpart).

- **telaio-security**: `DalRbacAdapter.canFilterOn(fieldPath, auth)` — new `default` hook (pass-through, existing adapters stay source-compatible). `DalSecurityInterceptor` asks it for every field referenced by a read filter (`FilterNodes.fieldNodes`), after `authorizeRead` (403 wins) and before the read runs.
- **telaio-core**: `DalFilterFieldNotReadableException` (a `DalInvalidFilterException`) — on the wire the same generic `400 "Invalid filter expression"` as an unknown field, so the filter cannot probe which hidden properties exist. `JsonPropertyPathResolver`'s path-walking rules (`isReferenceKeySegment`, `unwrapElements`, `isOpaque`, `isLeaf`) are now public and shared; the serialization view no longer lists `WRITE_ONLY` properties.
- **telaio-audit**: `SecurityDalAuditOutcomeClassifier` records the rejection as a **DENIED** event — probing hidden fields is an authorization signal, even though the client sees a plain client fault.
- **Both built-in adapters** implement the same rule — *filterable ⇔ present in the read response*: `PropertyBasedDalRbacAdapter` requires a serialized property granted in the read readable map (exact or granted descendant); `JsonViewDalRbacAdapter` requires the active read view on every declared property, map value beans included, with per-accessor `@JsonView` resolved getter-first like Jackson (`findViews()`). Wire name and Java name are both checked, so a rename offers no bypass. Server-side `defaultFilter()`s are combined inside the DAL, after the check, and are never subject to it.
- **Showcase**: `RbacFilterFieldIT` (property maps on `products`, `@JsonView` on `employees`); the `application.properties` override made redundant by Turkraft 4.1.0/#527 is dropped.
- **Docs**: security guide restructured around a `Product` running example defined up front; module/architecture docs, CHANGELOG, roadmap updated.

## Test plan

- [x] `mvn clean install` — full reactor green (core 144, security 134, audit 74+1, showcase 76 ITs incl. the new `RbacFilterFieldIT`)
- [x] Unit coverage: `DalSecurityInterceptorTest` (ordering 403→400→proceed, no-filter path), `PropertyBasedDalRbacAdapterTest` / `JsonViewDalRbacAdapterTest` (renames, nested paths, maps, per-accessor views, write-only), `NoopDalRbacAdapterTest`, `DalFilterFieldNotReadableExceptionTest`, `DalAuditOutcomeClassifierTest` (DENIED vs VALIDATION)
- [x] Review panel (java-architect, code-reviewer, security-auditor, microservices-architect, documentation-engineer): blocking finding (per-accessor `@JsonView` getter/setter mismatch) and all should-fixes resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
