### PR TITLE
chore(deps): upgrade Turkraft Spring Filter to 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,7 @@ field-name resolution moved to application-wide beans, which breaks a few APIs.
 
 ### 🔨 Dependency Upgrades
 
-- Turkraft Spring Filter 4.0.1 → 4.1.0 (BSON-native Mongo filter conversion, `@DBRef` filtering,
-  xor fix)
+- Turkraft Spring Filter 4.0.1 → 4.1.1.
 
 ## [1.1.0] - 2026-07-29
 

--- a/telaio-bom/pom.xml
+++ b/telaio-bom/pom.xml
@@ -35,7 +35,7 @@
     </licenses>
 
     <properties>
-        <turkraft-springfilter.version>4.1.0</turkraft-springfilter.version>
+        <turkraft-springfilter.version>4.1.1</turkraft-springfilter.version>
         <springdoc-openapi-starter-webmvc-ui.version>3.1.0</springdoc-openapi-starter-webmvc-ui.version>
         <swagger-bom.version>2.2.54</swagger-bom.version>
         <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>

--- a/telaio-jpa/src/test/java/com/paganbit/telaio/jpa/JpaDalFilterLanguageIntegrationTest.java
+++ b/telaio-jpa/src/test/java/com/paganbit/telaio/jpa/JpaDalFilterLanguageIntegrationTest.java
@@ -54,13 +54,12 @@ import static org.mockito.Mockito.mock;
  * six-row dataset, and asserts the rows each filter selects.
  *
  * <p>The vocabulary under test is the 21 shared core definitions plus the 45 functions of
- * {@code jpa-language}, two of which cannot run here: {@code jsonText} compiles to PostgreSQL's
- * {@code jsonb_extract_path_text} (no H2 equivalent) and {@code countDistinct} has no JPA processor
- * (asserted as a rejected filter). Backend-specific semantics are pinned as they are — {@code today()} is
- * the current day <em>name</em>, {@code ~} keeps SQL {@code %}/{@code _} wildcards live, {@code is empty}
- * on a string never matches — so a change in Turkraft's behavior fails here first. Error classification
- * is pinned too: unknown fields and unsupported functions are client faults, unconvertible literals are
- * server faults, the same way on every backend.</p>
+ * {@code jpa-language}, one of which cannot run here: {@code jsonText} compiles to PostgreSQL's
+ * {@code jsonb_extract_path_text} (no H2 equivalent). Backend-specific semantics are pinned as they are —
+ * {@code today()} is the current day <em>name</em>, {@code ~} keeps SQL {@code %}/{@code _} wildcards live,
+ * {@code is empty} on a string never matches — so a change in Turkraft's behavior fails here first. Error
+ * classification is pinned too: unknown fields and unsupported functions are client faults, unconvertible
+ * literals are server faults, the same way on every backend.</p>
  *
  * <p>Uses a plain {@code @SpringBootTest} because {@code @DataJpaTest} excludes Turkraft's and telaio's
  * autoconfigurations; the class-level transaction rolls the seed back after each test.</p>
@@ -185,6 +184,12 @@ class JpaDalFilterLanguageIntegrationTest {
             c("lines.status : 'shipped'", 1, 3, 5, 6),
             c("lines.amount > 200", 3, 5),
             c("lines is empty", 2),
+            // Each side of `or`/`xor` is its own EXISTS. An empty collection on one side no longer drops the
+            // row, and `tags : 'a' xor tags : 'b'` reads as "has a" xor "has b".
+            c("tags : 'red' or tags is empty", 1, 2, 4, 6),
+            c("quantity : 0 or lines.status : 'shipped'", 1, 2, 3, 5, 6),
+            c("tags : 'red' xor tags : 'blue'", 1, 3),
+            c("lines.status : 'shipped' xor lines.amount > 200", 1, 6),
             c("supplier.name : 'Acme'", 1, 2),
             c("supplier.country in ['US', 'DE']", 3, 5, 6),
             c("supplier is null", 4),
@@ -238,6 +243,7 @@ class JpaDalFilterLanguageIntegrationTest {
             c("max(lines.amount) >: 100", 1, 3, 5),
             c("min(lines.amount) < 20", 4),
             c("count(lines) > 1", 1, 4, 6),
+            c("countDistinct(lines.status) > 1", 1, 4),
             c("greatest(lines.amount) > 400", 5),
             c("least(lines.amount) < 30", 4, 6),
             c("exists(lines.status : 'pending' and lines.amount > 15)", 1, 4),
@@ -277,9 +283,7 @@ class JpaDalFilterLanguageIntegrationTest {
             Arguments.of("createdAt.nano : 0"),
             // properties the wire exposes but the persistence unit does not map (@Transient), root and nested
             Arguments.of("profit > 10"),
-            Arguments.of("lines.subtotal > 1"),
-            // a function the parser knows but the JPA backend has no processor for
-            Arguments.of("countDistinct(lines.status) > 1")
+            Arguments.of("lines.subtotal > 1")
         );
     }
 

--- a/telaio-mongo/src/test/java/com/paganbit/telaio/mongo/MongoDalFilterLanguageIntegrationTest.java
+++ b/telaio-mongo/src/test/java/com/paganbit/telaio/mongo/MongoDalFilterLanguageIntegrationTest.java
@@ -211,6 +211,11 @@ class MongoDalFilterLanguageIntegrationTest {
             c("size(lines) >: 2", 1, 4, 6),
             c("'shipped' in lines.status", 1, 3, 5, 6),
             c("lines is empty", 2),
+            // or/xor over arrays, aligned with the JPA cases
+            c("'red' in tags or tags is empty", 1, 2, 4, 6),
+            c("quantity : 0 or 'shipped' in lines.status", 1, 2, 3, 5, 6),
+            c("'red' in tags xor 'blue' in tags", 1, 3),
+            c("'shipped' in lines.status or 'pending' in lines.status", 1, 3, 4, 5, 6),
             // --- map fields: keys are dynamic, so unknown keys match nothing instead of failing ---
             c("attributes.color : 'red'", 1, 4),
             c("attributes.color in ['red', 'blue']", 1, 3, 4),
@@ -249,6 +254,8 @@ class MongoDalFilterLanguageIntegrationTest {
             c("id : '{id:G1}'", 1),
             c("id in ['{id:G1}', '{id:G3}']", 1, 3),
             c("id ! '{id:G1}'", 2, 3, 4, 5, 6),
+            // `~` on the String @Id string-matches through Turkraft's $function instead of comparing ObjectIds
+            c("id ~ '{id:G1}'", 1),
             c("ownerId : '{ownerId:G2}'", 2),
             c("ownerId in ['{ownerId:G1}', '{ownerId:G4}']", 1, 4),
             c("externalId : '11111111-1111-1111-1111-111111111111'", 1),


### PR DESCRIPTION
## Summary

Turkraft Spring Filter 4.1.0 → 4.1.1 (GA on Maven Central since 2026-09-03). Single pin in `telaio-bom`.

Upstream changes that touch Telaio, all pinned by the filter-language ITs:

- JPA `or` / `xor` evaluate each side in its own `EXISTS`: rows with an empty to-many on one side are no longer dropped, and `tags : 'a' xor tags : 'b'` reads as "has a" xor "has b".
- `countDistinct()` is now a supported JPA function (moved from the rejected filters to the positive cases).
- `InvalidSyntaxException` carries `@ResponseStatus(400)`, parser nesting cap of 500 (`springfilter.core.max_nesting_depth`), multi-line filters, `like` escaping on Mongo String `@Id`: no behaviour change for Telaio (malformed filters were already a 400).

## Changes

- `telaio-bom/pom.xml`: version property 4.1.1
- `CHANGELOG.md`: Dependency Upgrades entry
- `JpaDalFilterLanguageIntegrationTest`: 4 `or`/`xor`-over-collection cases, `countDistinct` positive case, class Javadoc aligned
- `MongoDalFilterLanguageIntegrationTest`: 4 mirrored `or`/`xor` cases, `id ~` on the String `@Id`

## Verification

- `mvn clean verify` (JDK 25, Testcontainers): BUILD SUCCESS, 1428 tests, 0 failures (baseline 1419 + 9 new cases)
- `dependency:tree`: every `com.turkraft.springfilter` artifact at 4.1.1; no jar-root `application.properties` in the 4.1.1 jars
