### PR TITLE
refactor: one read path per DAL on JPA and Mongo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   two; an existing `findAll(Pageable)` override keeps compiling but is no longer used by the DAL.
   If you customized `findAll(Pageable)` (entity graph, lock, query hints), move the annotation to
   `findAll(Specification, Pageable)`.
+- **One read path on Mongo too.** `MongoDal` runs every list, filtered or not, as a `Query` on
+  `MongoOperations`; the repository is used for writes only. An unfiltered list no longer issues an
+  unconditional count before the page is fetched. A `findAll(Pageable)` override in a
+  `MongoDalRepository` keeps compiling but is no longer reached by the DAL, and repository-level
+  read annotations (`@ReadPreference`, `@Meta`, `@Hint`) no longer affect DAL reads either.
+  Customize reads by overriding `executeRead` or `executeReadOne` on the DAL.
 
 ## [2.0.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### 🔄 Improvements
+
+- **One repository override covers the whole list read on JPA.** `JpaDal` now lists through
+  `findAll(Specification, Pageable)` only, passing an unrestricted specification when no filter is
+  given. An `@EntityGraph` (or any other customization) on the list read is one override instead of
+  two; an existing `findAll(Pageable)` override keeps compiling but is no longer used by the DAL.
+  If you customized `findAll(Pageable)` (entity graph, lock, query hints), move the annotation to
+  `findAll(Specification, Pageable)`.
+
 ## [2.0.0] - 2026-09-03
 
 MongoDB joins JPA as a shipped backend, field-level security now also covers filtering and

--- a/docs/modules/jpa.md
+++ b/docs/modules/jpa.md
@@ -25,7 +25,7 @@ querying) are on the roadmap and plug into the same contract.
 | Type                     | Purpose                                                                                                                                                                                                       |
 |--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `JpaDal<E, I>`           | Extends `AbstractDal`, implements `JpaDalMetadata`. Delegates CRUD to `JpaDalRepository` and converts filters to JPA `Specification`. Setter-injects `repository`, `entityManager`, `specificationConverter`. |
-| `JpaDalRepository<T, I>` | Spring Data `@NoRepositoryBean` interface extending `JpaRepositoryImplementation`. Developers write: `interface XRepository extends JpaDalRepository<X, Long> {}`. No custom methods needed.                  |
+| `JpaDalRepository<T, I>` | Spring Data `@NoRepositoryBean` interface extending `JpaRepositoryImplementation`. Developers write: `interface XRepository extends JpaDalRepository<X, Long> {}`. No custom methods needed; reads can be customized by overriding `findOne(Specification)` and `findAll(Specification, Pageable)` (see 3b). |
 | `JpaDalMetadata<E, I>`   | Read-only: `JpaDalRepository<E,I> getRepository()` + `EntityType<E> getEntityType()`. Exposes the backing repository and JPA metamodel introspection.                                                         |
 
 ### Support
@@ -106,6 +106,31 @@ public class ProductDalService extends JpaDal<Product, Long> {
     }
 }
 ```
+
+### 3b. (Optional) Apply an Entity Graph to Reads
+
+`JpaDal` reads through exactly two repository methods: `findOne(Specification)` for single-entity reads
+(`readOne`, the re-read at the end of `update`, the pre-check of `delete`) and `findAll(Specification, Pageable)`
+for lists. A list without a filter still goes through `findAll(Specification, Pageable)`, with
+`Specification.unrestricted()`. Overriding those two methods is therefore enough to customize every read,
+for example to fetch a `LAZY` association with a named entity graph:
+
+```java
+public interface EmployeeRepository extends JpaDalRepository<Employee, Long> {
+
+    @EntityGraph("Employee.withDepartment")
+    @Override
+    Optional<Employee> findOne(Specification<Employee> spec);
+
+    @EntityGraph("Employee.withDepartment")
+    @Override
+    Page<Employee> findAll(Specification<Employee> spec, Pageable pageable);
+}
+```
+
+The DAL does not read through `findById`; `save` and `delete` are write paths. None of them need an override.
+An existing `findAll(Pageable)` override is no longer reached by the DAL: move its annotations to
+`findAll(Specification, Pageable)`.
 
 ### 4. Override Lifecycle Hooks
 

--- a/docs/modules/mongo.md
+++ b/docs/modules/mongo.md
@@ -1,16 +1,17 @@
 # Telaio: Mongo Module
 
 The Mongo module is the **MongoDB backend implementation** of the persistence-agnostic DAL abstraction, built on Spring
-Data MongoDB. It delegates CRUD operations to a Spring Data Mongo repository and converts Turkraft filter expressions to
-Mongo queries.
+Data MongoDB. It writes through a Spring Data Mongo repository, reads through `MongoOperations`, and converts Turkraft
+filter expressions to Mongo queries.
 
 The core contract knows nothing about MongoDB — `Dal`/`AbstractDal` use only Spring Data's paging/sorting abstractions,
 and a backend implements the `execute*` SPI.
 
 ## Purpose
 
-- **Spring Data MongoDB integration:** Transparent delegation to your repository (plus `MongoOperations` for filtered
-  reads — `MongoRepository` has no specification-executor analogue)
+- **Spring Data MongoDB integration:** Writes go through your repository; every read (list, filtered or not, and by-id)
+  runs as a `Query` on `MongoOperations` — `MongoRepository` has no specification-executor analogue, and the DAL keeps
+  a single read path, so the repository is never on it
 - **Filter-to-Mongo conversion:** Dynamic Turkraft filter queries → Mongo `Query` (`$expr`-based)
 - **Type-safe repository definitions:** Minimal boilerplate interface declarations
 - **Setter-based injection:** Concrete DAL classes need no constructor in Spring
@@ -24,8 +25,8 @@ and a backend implements the `execute*` SPI.
 
 | Type                       | Purpose                                                                                                                                                                                                                                                     |
 |----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `MongoDal<E, I>`           | Extends `AbstractDal`, implements `MongoDalMetadata`. Delegates CRUD to `MongoDalRepository`, runs filtered reads through `MongoOperations`, converts filters via `FilterQueryConverter`. Setter-injects `repository`, `mongoOperations`, `queryConverter`. |
-| `MongoDalRepository<E, I>` | Spring Data `@NoRepositoryBean` interface extending `MongoRepository`. Developers write: `interface XRepository extends MongoDalRepository<X, String> {}`. No custom methods needed.                                                                        |
+| `MongoDal<E, I>`           | Extends `AbstractDal`, implements `MongoDalMetadata`. Writes through `MongoDalRepository`, runs every read through `MongoOperations`, converts filters via `FilterQueryConverter`. Setter-injects `repository`, `mongoOperations`, `queryConverter`.       |
+| `MongoDalRepository<E, I>` | Spring Data `@NoRepositoryBean` interface extending `MongoRepository`. Developers write: `interface XRepository extends MongoDalRepository<X, String> {}`. No custom methods needed; the DAL never reads through it, so overriding its read methods has no effect. |
 | `MongoDalMetadata<E, I>`   | Read-only: `MongoDalRepository<E,I> getRepository()` + `MongoPersistentEntity<E> getPersistentEntity()`. Exposes the backing repository and Spring Data mapping metadata.                                                                                   |
 
 ### Support

--- a/telaio-jpa/src/main/java/com/paganbit/telaio/jpa/JpaDal.java
+++ b/telaio-jpa/src/main/java/com/paganbit/telaio/jpa/JpaDal.java
@@ -159,10 +159,8 @@ public class JpaDal<E, I> extends AbstractDal<E, I> implements JpaDalMetadata<E,
     protected Page<E> executeRead(@Nullable FilterNode filter, Pageable pageable) {
         Specification<E> specification = filter != null
             ? specificationConverter().convert(filter)
-            : null;
-        return specification != null
-            ? getRepository().findAll(specification, pageable)
-            : getRepository().findAll(pageable);
+            : Specification.unrestricted();
+        return getRepository().findAll(specification, pageable);
     }
 
     @Override

--- a/telaio-jpa/src/main/java/com/paganbit/telaio/jpa/JpaDalRepository.java
+++ b/telaio-jpa/src/main/java/com/paganbit/telaio/jpa/JpaDalRepository.java
@@ -1,5 +1,7 @@
 package com.paganbit.telaio.jpa;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.support.JpaRepositoryImplementation;
 import org.springframework.data.repository.NoRepositoryBean;
 
@@ -8,7 +10,23 @@ import org.springframework.data.repository.NoRepositoryBean;
  * <p>
  * This interface extends {@link JpaRepositoryImplementation} to provide
  * basic CRUD operations for entities in the DAL context.
- * </p>
+ * <p>
+ * The base {@code JpaDal} reads through exactly two methods: {@link #findOne(Specification)} for single-entity
+ * reads and {@link #findAll(Specification, Pageable)} for lists. A list without a filter still uses
+ * the latter, with {@link Specification#unrestricted()}. Overriding those two methods is enough to
+ * customize every read, for example to apply an entity graph:
+ * <pre>{@code
+ * public interface EmployeeRepository extends JpaDalRepository<Employee, Long> {
+ *
+ *     @EntityGraph("Employee.withDepartment")
+ *     @Override
+ *     Optional<Employee> findOne(Specification<Employee> spec);
+ *
+ *     @EntityGraph("Employee.withDepartment")
+ *     @Override
+ *     Page<Employee> findAll(Specification<Employee> spec, Pageable pageable);
+ * }
+ * }</pre>
  *
  * @param <T> the entity type
  * @param <I> the entity identifier type

--- a/telaio-jpa/src/test/java/com/paganbit/telaio/jpa/JpaDalTest.java
+++ b/telaio-jpa/src/test/java/com/paganbit/telaio/jpa/JpaDalTest.java
@@ -12,6 +12,9 @@ import com.turkraft.springfilter.converter.FilterSpecificationConverter;
 import com.turkraft.springfilter.converter.FilterStringConverter;
 import com.turkraft.springfilter.parser.node.FilterNode;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
 import jakarta.persistence.metamodel.EntityType;
 import jakarta.persistence.metamodel.Metamodel;
 import jakarta.validation.Validator;
@@ -19,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
@@ -262,15 +266,26 @@ class JpaDalTest {
     }
 
     @Test
-    void executeRead_withoutFilter_usesPageableOverloadAndSkipsConverter() {
+    @SuppressWarnings("unchecked")
+    void executeRead_withoutFilter_usesUnrestrictedSpecificationAndSkipsConverter() {
         TestJpaDal dal = readyDal();
         Pageable pageable = PageRequest.of(0, 10);
         Page<TestEntity> page = new PageImpl<>(List.of(new TestEntity()));
-        doReturn(page).when(repository).findAll(pageable);
+        doReturn(page).when(repository).findAll(any(Specification.class), eq(pageable));
 
         assertThat(dal.executeRead(null, pageable)).isSameAs(page);
-        verify(repository).findAll(pageable);
+
+        ArgumentCaptor<Specification<TestEntity>> captor = ArgumentCaptor.forClass(Specification.class);
+        verify(repository).findAll(captor.capture(), eq(pageable));
+        verify(repository, never()).findAll(any(Pageable.class));
         verifyNoInteractions(specificationConverter);
+
+        Root<TestEntity> root = mock(Root.class);
+        CriteriaQuery<?> query = mock(CriteriaQuery.class);
+        CriteriaBuilder builder = mock(CriteriaBuilder.class);
+        assertThat(captor.getValue().toPredicate(root, query, builder))
+            .as("a null filter maps to an unrestricted specification (no WHERE clause)")
+            .isNull();
     }
 
     @Test
@@ -287,6 +302,7 @@ class JpaDalTest {
         assertThat(dal.executeRead(filter, pageable)).isSameAs(page);
         verify(specificationConverter).convert(filter);
         verify(repository).findAll(spec, pageable);
+        verify(repository, never()).findAll(any(Pageable.class));
     }
 
     @Test

--- a/telaio-mongo/src/main/java/com/paganbit/telaio/mongo/MongoDal.java
+++ b/telaio-mongo/src/main/java/com/paganbit/telaio/mongo/MongoDal.java
@@ -27,8 +27,8 @@ import java.util.Optional;
 /**
  * MongoDB-based implementation of {@link com.paganbit.telaio.core.Dal Dal}.
  * <p>
- * Provides CRUD execution through {@link MongoDalRepository} and exposes Mongo-specific
- * metadata through {@link MongoDalMetadata}.
+ * Writes go through {@link MongoDalRepository}; every read runs as a {@link Query} on
+ * {@link MongoOperations}. Mongo-specific metadata is exposed through {@link MongoDalMetadata}.
  * <p>
  * Like {@link AbstractDal}, this class relies on setter-based injection so that concrete
  * subclasses stay free of boilerplate. In a Spring context a subclass typically needs no
@@ -72,7 +72,7 @@ public class MongoDal<E, I> extends AbstractDal<E, I> implements MongoDalMetadat
     private static final String RAW_ID_FIELD = "_id";
 
     /**
-     * The repository used for CRUD operations on the entity.
+     * The repository used for writes ({@code save}, {@code delete}) on the entity.
      * This repository is expected to be a Mongo repository that extends {@link MongoDalRepository}.
      * {@code null} only between construction and setter injection; non-null once the bean is fully
      * initialized (see {@link #afterPropertiesSet()}). Access internally via {@link #getRepository()}.
@@ -80,7 +80,7 @@ public class MongoDal<E, I> extends AbstractDal<E, I> implements MongoDalMetadat
     protected @Nullable MongoDalRepository<E, I> repository;
 
     /**
-     * The template-level Mongo access used for filtered reads and by-id lookups.
+     * The template-level Mongo access used for every read: lists and by-id lookups.
      * This is typically injected by Spring and provides access to the MongoDB context.
      * {@code null} only between construction and setter injection.
      */
@@ -209,10 +209,9 @@ public class MongoDal<E, I> extends AbstractDal<E, I> implements MongoDalMetadat
 
     @Override
     protected Page<E> executeRead(@Nullable FilterNode filter, Pageable pageable) {
-        if (filter == null) {
-            return getRepository().findAll(pageable);
-        }
-        Query query = queryConverter().convert(filter, getEntityClass());
+        Query query = filter != null
+            ? queryConverter().convert(filter, getEntityClass())
+            : new Query();
         List<E> content = mongoOperations().find(Query.of(query).with(pageable), getEntityClass());
         return PageableExecutionUtils.getPage(content, pageable,
             () -> mongoOperations().count(Query.of(query).limit(-1).skip(-1), getEntityClass()));

--- a/telaio-mongo/src/main/java/com/paganbit/telaio/mongo/MongoDalRepository.java
+++ b/telaio-mongo/src/main/java/com/paganbit/telaio/mongo/MongoDalRepository.java
@@ -8,7 +8,14 @@ import org.springframework.data.repository.NoRepositoryBean;
  * <p>
  * This interface extends {@link MongoRepository} to provide
  * basic CRUD operations for entities in the DAL context.
- * </p>
+ * <p>
+ * The DAL never reads through the repository: lists and by-id lookups run as
+ * {@link org.springframework.data.mongodb.core.query.Query Query} objects on
+ * {@link org.springframework.data.mongodb.core.MongoOperations MongoOperations}. The repository
+ * serves {@code save} and {@code delete}, so read-method overrides and read annotations on the
+ * repository have no effect on the DAL. Customize reads by overriding
+ * {@link MongoDal#executeRead(com.turkraft.springfilter.parser.node.FilterNode, org.springframework.data.domain.Pageable) executeRead}
+ * or {@link MongoDal#executeReadOne(Object) executeReadOne} instead.
  *
  * @param <E> the entity type
  * @param <I> the entity identifier type

--- a/telaio-mongo/src/test/java/com/paganbit/telaio/mongo/MongoDalIntegrationTest.java
+++ b/telaio-mongo/src/test/java/com/paganbit/telaio/mongo/MongoDalIntegrationTest.java
@@ -156,6 +156,19 @@ class MongoDalIntegrationTest {
         assertThat(page.getContent()).hasSize(2);
     }
 
+    @Test
+    void executeRead_withoutFilterAndFullPage_countsTheWholeCollection() {
+        persisted("a");
+        persisted("b");
+        persisted("c");
+
+        Page<TestEntity> page = dal.executeRead(null, PageRequest.of(0, 2, Sort.by("id")));
+
+        assertThat(page.getContent()).extracting(TestEntity::getName).containsExactly("a", "b");
+        assertThat(page.getTotalElements()).isEqualTo(3);
+        assertThat(page.getTotalPages()).isEqualTo(2);
+    }
+
     /**
      * Runs the exact query shape {@code JsonAwareFilterQueryConverter} produces ({@code $expr}
      * aggregation expression) through {@code find} + {@code count} + paging against a real server —

--- a/telaio-mongo/src/test/java/com/paganbit/telaio/mongo/MongoDalTest.java
+++ b/telaio-mongo/src/test/java/com/paganbit/telaio/mongo/MongoDalTest.java
@@ -20,7 +20,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mapping.context.MappingContext;
@@ -272,16 +271,43 @@ class MongoDalTest {
     }
 
     @Test
-    void executeRead_withoutFilter_usesPageableOverloadAndSkipsConverter() {
+    void executeRead_withoutFilter_usesEmptyQueryViaMongoOperationsAndSkipsConverter() {
         TestMongoDal dal = readyDal();
         Pageable pageable = PageRequest.of(0, 10);
-        Page<TestEntity> page = new PageImpl<>(List.of(new TestEntity()));
-        doReturn(page).when(repository).findAll(pageable);
+        TestEntity entity = new TestEntity();
+        doReturn(List.of(entity)).when(mongoOperations).find(any(Query.class), eq(TestEntity.class));
 
-        assertThat(dal.executeRead(null, pageable)).isSameAs(page);
-        verify(repository).findAll(pageable);
+        Page<TestEntity> page = dal.executeRead(null, pageable);
+
+        assertThat(page.getContent()).containsExactly(entity);
+        assertThat(page.getTotalElements()).isEqualTo(1);
         verifyNoInteractions(queryConverter);
-        verify(mongoOperations, never()).find(any(Query.class), eq(TestEntity.class));
+        verifyNoInteractions(repository);
+        ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+        verify(mongoOperations).find(queryCaptor.capture(), eq(TestEntity.class));
+        assertThat(queryCaptor.getValue().getQueryObject()).isEmpty();
+        assertThat(queryCaptor.getValue().getLimit()).isEqualTo(10);
+        assertThat(queryCaptor.getValue().getSkip()).isZero();
+        verify(mongoOperations, never()).count(any(Query.class), eq(TestEntity.class));
+    }
+
+    @Test
+    void executeRead_withoutFilterAndFullPage_countsWithPagingCleared() {
+        TestMongoDal dal = readyDal();
+        Pageable pageable = PageRequest.of(1, 2);
+        doReturn(List.of(new TestEntity(), new TestEntity()))
+            .when(mongoOperations).find(any(Query.class), eq(TestEntity.class));
+        doReturn(7L).when(mongoOperations).count(any(Query.class), eq(TestEntity.class));
+
+        Page<TestEntity> page = dal.executeRead(null, pageable);
+
+        assertThat(page.getTotalElements()).isEqualTo(7);
+        ArgumentCaptor<Query> countCaptor = ArgumentCaptor.forClass(Query.class);
+        verify(mongoOperations).count(countCaptor.capture(), eq(TestEntity.class));
+        assertThat(countCaptor.getValue().getQueryObject()).isEmpty();
+        assertThat(countCaptor.getValue().isLimited()).isFalse();
+        assertThat(countCaptor.getValue().getSkip()).isLessThanOrEqualTo(0);
+        verifyNoInteractions(repository);
     }
 
     @Test

--- a/telaio-showcase/src/main/java/com/paganbit/telaio/showcase/dal/employee/EmployeeRepository.java
+++ b/telaio-showcase/src/main/java/com/paganbit/telaio/showcase/dal/employee/EmployeeRepository.java
@@ -13,10 +13,11 @@ import java.util.Optional;
  * entity graph} to the read methods the DAL uses, so the {@code LAZY} {@code department} association is
  * fetched on those paths (and serialized outside the session) without a global EAGER fetch.
  *
- * <p>{@code JpaDal} reads exclusively through these methods — {@code findOne(Specification)} for
- * {@code readOne} (also the re-read at the end of {@code update}) and {@code findAll(...)} for the list —
- * so overriding them with {@code @EntityGraph("Employee.withDepartment")} is enough to cover every read.
- * Writes ({@code save}, {@code deleteById}) and {@code findById} (unused by the DAL) need no graph.</p>
+ * <p>{@code JpaDal} reads exclusively through these two methods. {@code findOne(Specification)} serves
+ * {@code readOne}, the re-read at the end of {@code update} and the pre-check of {@code delete};
+ * {@code findAll(Specification, Pageable)} serves the list, filtered or not. Overriding them with
+ * {@code @EntityGraph("Employee.withDepartment")} is therefore enough to cover every read.
+ * Writes ({@code save}, {@code delete}) and {@code findById} (unused by the DAL) need no graph.</p>
  */
 public interface EmployeeRepository extends JpaDalRepository<Employee, Long> {
 
@@ -27,8 +28,4 @@ public interface EmployeeRepository extends JpaDalRepository<Employee, Long> {
     @EntityGraph("Employee.withDepartment")
     @Override
     Page<Employee> findAll(Specification<Employee> spec, Pageable pageable);
-
-    @EntityGraph("Employee.withDepartment")
-    @Override
-    Page<Employee> findAll(Pageable pageable);
 }

--- a/telaio-showcase/src/test/java/com/paganbit/telaio/showcase/it/EmployeeDepartmentRelationIT.java
+++ b/telaio-showcase/src/test/java/com/paganbit/telaio/showcase/it/EmployeeDepartmentRelationIT.java
@@ -61,6 +61,28 @@ class EmployeeDepartmentRelationIT extends AbstractShowcaseIT {
     }
 
     @Test
+    void departmentIsReadAsANestedObjectOnList() {
+        long engineeringId = departmentId("Engineering");
+        String employeeId = createEmployee(engineeringId);
+
+        JsonNode filtered = employeeInList(list(DEVELOPER, EMPLOYEES, "q=id:" + employeeId), employeeId);
+        assertThat(filtered.get("department").get("name").asString()).isEqualTo("Engineering");
+
+        JsonNode unfiltered = employeeInList(list(DEVELOPER, EMPLOYEES, "size=100&sort=id,desc"), employeeId);
+        assertThat(unfiltered.get("department").get("name").asString()).isEqualTo("Engineering");
+    }
+
+    private JsonNode employeeInList(ResponseEntity<String> response, String employeeId) {
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        for (JsonNode employee : tree(response).get("content")) {
+            if (employeeId.equals(employee.get("id").asString())) {
+                return employee;
+            }
+        }
+        throw new AssertionError("employee " + employeeId + " not found in the list");
+    }
+
+    @Test
     void repointMovesEmployeeToAnotherDepartmentViaWriteOnlyId() {
         long engineeringId = departmentId("Engineering");
         long designId = departmentId("Design");


### PR DESCRIPTION
## Summary

- **JPA:** `JpaDal` lists through `findAll(Specification, Pageable)` only; a null filter maps to `Specification.unrestricted()`. An `@EntityGraph` (or any other customization) on the list read is one repository override instead of two. Same execution path as before: in Spring Data JPA 4.1.1 `SimpleJpaRepository.findAll(Pageable)` is itself `findAll(Specification.unrestricted(), pageable)`.
- **Mongo:** `MongoDal` runs every list, filtered or not, as one `Query` on `MongoOperations` with a paging-cleared count. The repository serves writes only; an unfiltered list no longer issues an unconditional count before fetching the page.
- Showcase `EmployeeRepository` drops the now-unused `findAll(Pageable)` override; a new IT pins the entity graph on filtered and unfiltered lists.
- Docs (`docs/modules/jpa.md`, `docs/modules/mongo.md`) and CHANGELOG updated. Non-breaking: existing `findAll(Pageable)` overrides keep compiling but are no longer reached by the DAL.

## Test plan

- [x] `mvn -pl telaio-jpa -am test` (238 tests)
- [x] `mvn -pl telaio-mongo -am test` (257 tests, Testcontainers)
- [x] `mvn -pl telaio-showcase -am test -Dtest=EmployeeDepartmentRelationIT` (Testcontainers)
- [x] Full reactor `test-compile` on JDK 25, telaio-mongo Javadoc build
- [ ] CI `build` green

